### PR TITLE
(#12) Basic SRV support

### DIFF
--- a/lib/mcollective/discovery/choria.rb
+++ b/lib/mcollective/discovery/choria.rb
@@ -216,18 +216,8 @@ module MCollective
       def https
         @_https ||= begin
                       choria.check_ssl_setup
-                      choria.https
+                      choria.https(choria.puppetdb_server)
                     end
-      end
-
-      # (see Util::Choria#puppetdb_server)
-      def puppetdb_server
-        choria.puppetdb_server
-      end
-
-      # (see Util::Choria#puppetdb_port)
-      def puppetdb_port
-        choria.puppetdb_port
       end
     end
   end


### PR DESCRIPTION
Adds basic SRV support

  puppet: _x-puppet._tcp
  puppetca: _x-puppet-ca._tcp, _x-puppet._tcp
  puppetdb: _x-puppet-db._tcp, _x-puppet._tcp

Closes #12 