### PR TITLE
(#22) Improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2016/07/29|22    |Improve handling of errors from the nodes                                                                |
 |2016/07/26|20    |Fix incorrect module data                                                                                |
 |2016/07/23|10    |Import mcollective-connector-nats                                                                        |
 |2016/07/23|8     |Import mcollective-discovery-puppetdb as `choria` discovery provider                                     |


### PR DESCRIPTION
Previously almost none of the RPC messages were actually error checked
meaning things like policy mismatches would go unnoticed and deploys
would kind of silently fail

They are now all checked and raises appropriate errors.  On error nodes
are disabled as this might leave them in a bad state

Closes #22 