### PR TITLE
(#29) fix discovery of sub classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2016/08/01|      |Release 0.0.5                                                                                            |
+|2016/08/01|29    |Fix discovery of rpcutil and subclasses                                                                  |
 |2016/08/01|      |Release 0.0.4                                                                                            |
 |2016/08/01|27    |Install client files only on clients and not everywhere                                                  |
 |2016/08/01|27    |Improve discovery of agents in cases where there are client only installs                                |

--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,7 @@ end
 
 desc "Prepare and build the Puppet module"
 task :release do
+  sh("mkdir -p module/files/mcollective")
   sh("rm -rf module/files/mcollective/*")
   sh("cp -rv lib/mcollective/* module/files/mcollective/")
   sh("cp CHANGELOG.md COPYING module")

--- a/lib/mcollective/discovery/choria.rb
+++ b/lib/mcollective/discovery/choria.rb
@@ -66,7 +66,7 @@ module MCollective
           end
         end
 
-        pql.join(" or ") unless pql.empty?
+        pql.join(" and ") unless pql.empty?
       end
 
       # Turns a string into a case insensitive regex string
@@ -83,6 +83,16 @@ module MCollective
             char
           end
         end.join
+      end
+
+      # Capitalize a Puppet Resource
+      #
+      # foo::bar => Foo::Bar
+      #
+      # @param resource [String] a resource title
+      # @return [String]
+      def capitalize_resource(resource)
+        resource.split("::").map(&:capitalize).join("::")
       end
 
       # Searches for facts
@@ -130,7 +140,7 @@ module MCollective
           if klass =~ /^\/(.+)\/$/
             'resources {type = "Class" and title ~ "%s"}' % [string_regexi($1)]
           else
-            'resources {type = "Class" and title = "%s"}' % [klass.capitalize]
+            'resources {type = "Class" and title = "%s"}' % [capitalize_resource(klass)]
           end
         end
 

--- a/module/metadata.json
+++ b/module/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ripienaar-mcollective_choria",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": "R.I.Pienaar <rip@devco.net>",
   "summary": "A suite of MCollective Plugins for AIO Puppet",
   "license": "Apache-2.0",

--- a/spec/unit/mcollective/discovery/choria_spec.rb
+++ b/spec/unit/mcollective/discovery/choria_spec.rb
@@ -6,6 +6,15 @@ module MCollective
   describe Discovery::Choria do
     let(:discovery) { Discovery::Choria.new({}, 10, 1, stub) }
 
+    describe "#capitalize_resource" do
+      it "should correctly capitalize resources" do
+        expect(discovery.capitalize_resource("foo")).to eq("Foo")
+        expect(discovery.capitalize_resource("Foo")).to eq("Foo")
+        expect(discovery.capitalize_resource("foo::bar")).to eq("Foo::Bar")
+        expect(discovery.capitalize_resource("Foo::Bar")).to eq("Foo::Bar")
+      end
+    end
+
     describe "#query" do
       it "should query and parse" do
         discovery.choria.expects(:check_ssl_setup)
@@ -104,7 +113,7 @@ module MCollective
         # rubocop:disable Metrics/LineLength
         expect(
           discovery.discover_agents(["rpcutil", "rspec1", "/rs/"])
-        ).to eq('resources {type = "Class" and title = "Mcollective::service"} or resources {type = "File" and tag = "mcollective_agent_rspec1_server"} or resources {type = "File" and tag ~ "mcollective_agent_.*?[rR][sS].*?_server"}')
+        ).to eq('resources {type = "Class" and title = "Mcollective::Service"} and resources {type = "File" and tag = "mcollective_agent_rspec1_server"} and resources {type = "File" and tag ~ "mcollective_agent_.*?[rR][sS].*?_server"}')
         # rubocop:enable Metrics/LineLength
       end
     end


### PR DESCRIPTION
subclasses should be capitalized as Foo::Bar when searching PuppetDB but
this only did a dumb .capitalize so this never worked

Closes #29 