### PR TITLE
(#37) Handle empty catalogs better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2016/08/10|37    |Improve errors when a empty site catalog is found                                                        |
 |2016/08/01|      |Release 0.0.5                                                                                            |
 |2016/08/01|29    |Fix discovery of rpcutil and subclasses                                                                  |
 |2016/08/01|      |Release 0.0.4                                                                                            |

--- a/lib/mcollective/application/choria.rb
+++ b/lib/mcollective/application/choria.rb
@@ -139,11 +139,13 @@ module MCollective
       def run_command
         puts orchestrator.to_s
 
-        confirm("Are you sure you wish to run this plan?")
+        unless orchestrator.empty?
+          confirm("Are you sure you wish to run this plan?")
 
-        puts
+          puts
 
-        orchestrator.run_plan
+          orchestrator.run_plan
+        end
       end
 
       # Creates and cache a client to the Puppet RPC Agent

--- a/lib/mcollective/util/choria/orchestrator.rb
+++ b/lib/mcollective/util/choria/orchestrator.rb
@@ -16,6 +16,10 @@ module MCollective
           @batch_size = batch_size
         end
 
+        def empty?
+          environment.applications.empty?
+        end
+
         def time_stamp
           Time.now
         end
@@ -258,6 +262,12 @@ module MCollective
 
           plan.puts("Puppet Site Plan for the %s Environment" % bold(environment.environment))
           plan.puts
+
+          if empty?
+            plan.puts("No site applications were found in the Puppet environment")
+            return(plan.string)
+          end
+
           plan.puts("%s applications on %s managed nodes:" % [bold(environment.applications.size), bold(environment.nodes.size)])
           plan.puts
 

--- a/lib/mcollective/util/choria/puppet_v3_environment.rb
+++ b/lib/mcollective/util/choria/puppet_v3_environment.rb
@@ -10,6 +10,15 @@ module MCollective
           @site = site
           @application = application
           @site_nodes = node_view
+        end
+
+        # Ensures the site catalog is resolvable
+        #
+        # When the catalog is empty this is a noop
+        #
+        # @raize [StandardError] on invalid catalog
+        def validate_site_catalog!
+          return if site_nodes.empty?
 
           unless has_runable_nodes?(node_view(false))
             raise(UserError, "Impossible to resolve site catalog found, cannot continue with any instances")


### PR DESCRIPTION
Previously when no site catalogs were defined an giant red error were
raise with a backtrace, this is not nice, now it just shows a statement
saying no site apps are defined

Closes #37 