### PR TITLE
(#37) Do not invoke orchestrator to show a red error

### DIFF
--- a/lib/mcollective/application/choria.rb
+++ b/lib/mcollective/application/choria.rb
@@ -78,7 +78,7 @@ module MCollective
         send("%s_command" % configuration[:command])
 
       rescue Util::Choria::UserError
-        STDERR.puts("Could not process site plan: %s" % orchestrator.red($!.to_s))
+        STDERR.puts("Encountered a critical error: %s" % Util.colorize(:red, $!.to_s))
 
       rescue Util::Choria::Abort
         exit(1)


### PR DESCRIPTION
On UserError a red error line is shown, this was colorised using
orchestrator.red, which starts the orchestrator and tries to talk to
puppetserver and all sorts of side effects - which then fails and hide
the real error.

Use Util.colorize() instead