### PR TITLE
(#44) Fix calling facter.bat on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2016/08/13|45    |Fix calling facter on windows                                                                            |
 |2016/08/11|      |Release 0.0.6                                                                                            |
 |2016/08/10|34    |Correctly declare Apache-2.0 licence                                                                     |
 |2016/08/10|37    |Improve errors when a empty site catalog is found                                                        |

--- a/lib/mcollective/util/choria.rb
+++ b/lib/mcollective/util/choria.rb
@@ -36,7 +36,7 @@ module MCollective
       # @return [String,nil]
       def facter_domain
         if path = facter_cmd
-          `#{path} networking.domain`.chomp
+          `"#{path}" networking.domain`.chomp
         end
       end
 


### PR DESCRIPTION
When backticking programs on windows paths should be quoted, always
quote it

Close #44 