### PR TITLE
(#42) Support 0.8.0 of the NATS gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2016/08/19|42    |Support NATS gem 0.8.0 and log connected clients                                                         |
 |2016/08/13|      |Release 0.0.7                                                                                            |
 |2016/08/13|45    |Fix calling facter on windows                                                                            |
 |2016/08/11|      |Release 0.0.6                                                                                            |

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "nats", "0.7.1"
+gem "nats", "0.8.0"
 
 group :development, :test do
   gem "json-schema-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     lumberjack (1.0.10)
-    mcollective-client (2.8.4)
+    mcollective-client (2.9.0)
       json
       stomp
       systemu
@@ -46,7 +46,7 @@ GEM
     method_source (0.8.2)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    nats (0.7.1)
+    nats (0.8.0)
       eventmachine (~> 1.2, >= 1.2.0)
     nenv (0.3.0)
     notiffany (0.1.1)
@@ -107,7 +107,7 @@ DEPENDENCIES
   listen (~> 3.0.0)
   mcollective-client
   mocha
-  nats (= 0.7.1)
+  nats (= 0.8.0)
   rake
   rspec
   rubocop (= 0.41.1)

--- a/module/data/plugin.yaml
+++ b/module/data/plugin.yaml
@@ -1,7 +1,7 @@
 ---
 mcollective_choria::config_name: choria
 mcollective_choria::gem_dependencies:
-    nats: "0.7.1"
+    nats: "0.8.0"
 
 mcollective_choria::client_files:
  - discovery/choria.ddl


### PR DESCRIPTION
Support version 0.8.0 of the NATS gem and add support for logging the
current connection pool.

When the NATS server has cluster announcements on the connection pool
will dynamically update at run time as cluster members come and go, this
logs those for visibility

Close #42 