### PR TITLE
(#49) Set the connection name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2016/08/19|49    |Set the connection name                                                                                  |
 |2016/08/19|42    |Support NATS gem 0.8.0 and log connected clients                                                         |
 |2016/08/13|      |Release 0.0.7                                                                                            |
 |2016/08/13|45    |Fix calling facter on windows                                                                            |

--- a/lib/mcollective/connector/nats.rb
+++ b/lib/mcollective/connector/nats.rb
@@ -29,7 +29,8 @@ module MCollective
           :max_reconnect_attempts => -1,
           :reconnect_time_wait => 1,
           :dont_randomize_servers => true,
-          :tls => ssl_parameters
+          :tls => ssl_parameters,
+          :name => @config.identity
         }
 
         servers = server_list

--- a/spec/unit/mcollective/connector/nats_spec.rb
+++ b/spec/unit/mcollective/connector/nats_spec.rb
@@ -58,6 +58,7 @@ module MCollective
           :max_reconnect_attempts => -1,
           :reconnect_time_wait => 1,
           :dont_randomize_servers => true,
+          :name => "rspec_identity",
           :tls => {
             :cert_chain_file => "/ssl/certs/rspec_identity.pem",
             :private_key_file => "/ssl/private_keys/rspec_identity.pem",


### PR DESCRIPTION
A future version of the NATS gem will take a :name property and set it
when connecting, this is visible when hitting up /connz on the NATS
server which is important for debugging

Closes #49 