### PR TITLE
(#35) Simplify the facts queries for sub collectives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2016/08/22|35    |Simplify facts queries using latest PuppetDB PQL                                                         |
 |2016/08/20|52    |Release 0.0.8                                                                                            |
 |2016/08/19|49    |Set the connection name                                                                                  |
-|2016/08/19|42    |Support NATS gem 0.8.0 and log connected clients                                                         |
+|2016/08/19|42    |Support NATS gem 0.8.0 and log connected NATS brokers                                                    |
 |2016/08/13|      |Release 0.0.7                                                                                            |
 |2016/08/13|45    |Fix calling facter on windows                                                                            |
 |2016/08/11|      |Release 0.0.6                                                                                            |

--- a/lib/mcollective/discovery/choria.rb
+++ b/lib/mcollective/discovery/choria.rb
@@ -42,7 +42,7 @@ module MCollective
       # @param filter [String] a collective name
       # @return [String] a query string
       def discover_collective(filter)
-        'certname in fact_contents[certname] {path ~> ["mcollective", "server", "collectives", "\\\\d"] and value = "%s"}' % filter
+        'certname in inventory[certname] { facts.mcollective.server.collectives.match("\d+") = "%s" }' % filter
       end
 
       # Searches for facts

--- a/spec/unit/mcollective/discovery/choria_spec.rb
+++ b/spec/unit/mcollective/discovery/choria_spec.rb
@@ -121,7 +121,7 @@ module MCollective
     describe "#discover_collective" do
       it "should search in facts" do
         expect(discovery.discover_collective("rspec_collective")).to eq(
-          'certname in fact_contents[certname] {path ~> ["mcollective", "server", "collectives", "\\\\d"] and value = "rspec_collective"}'
+          'certname in inventory[certname] { facts.mcollective.server.collectives.match("\d+") = "rspec_collective" }'
         )
       end
     end


### PR DESCRIPTION
Use the new dot notation in recent PuppetDB to simplify the sub
collective queries

Closes #35 