### PR TITLE
(#61) support PQL node identity searches

### DIFF
--- a/lib/mcollective/discovery/choria.rb
+++ b/lib/mcollective/discovery/choria.rb
@@ -158,7 +158,9 @@ module MCollective
           nil
         else
           pql = filter.map do |ident|
-            if ident =~ /^\/(.+)\/$/
+            if ident =~ /^pql:\s*(.+)$/
+              "certname in %s" % $1
+            elsif ident =~ /^\/(.+)\/$/
               'certname ~ "%s"' % string_regexi($1)
             else
               'certname = "%s"' % ident

--- a/spec/unit/mcollective/discovery/choria_spec.rb
+++ b/spec/unit/mcollective/discovery/choria_spec.rb
@@ -57,8 +57,8 @@ module MCollective
     describe "#discover_nodes" do
       it "should discover nodes correctly" do
         expect(
-          discovery.discover_nodes(["/x/", "y"])
-        ).to eq('certname ~ "[xX]" or certname = "y"')
+          discovery.discover_nodes(["/x/", "y", 'pql: nodes[certname] { facts_environment = "production" }'])
+        ).to eq('certname ~ "[xX]" or certname = "y" or certname in nodes[certname] { facts_environment = "production" }')
       end
     end
 


### PR DESCRIPTION
This adds the ability to use PQL in Identity searches to find nodes
using complex queries in PuppetDB

```
mco find -I 'pql: nodes[certname] { latest_report_status = "failed" }'
```

These queries are stuck into the rest of the PQL querie to filter nodes
further based on current sub collective and nodes that actually have
MCollective on them and runnning

The queries all have to return a list of hashes with certname as in the
example above