### PR TITLE
(#55) Consult puppet for ssl dir setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2016/11/19|55    |When root consult Puppet configuration to find the SSL dir, make ssl dir configurable                    |
 |2016/11/19|68    |Update eventmachine to 1.2.1 and install that by default, improve logging of EM mode and version         |
 |2016/11/01|      |Release 0.0.9                                                                                            |
 |2016/10/20|61    |Support PQL queries on the CLI for node discovery                                                        |


### PR DESCRIPTION
Some people want to configure Puppet in non AIO locations - and recent
Debian and Fedora packaged Puppet 4 into their own standards.  Generally
I am very against supporting people who do this but it makes sense in
the case of SSL at least since puppet has some design issues around that

So this commit adds a helper to configure puppet and fetch a setting
from it and updates the ssl_dir method to consult puppet when running as
root or windows.

Puppet is not consulted when running as a normal user because just doing
require puppet takes a second which is too long.

For normal users they can now configure choria.ssldir in the config file
which may include things like ~ for home dir expansion