### PR TITLE
(#83) Fix initialization of Puppet

### DIFF
--- a/lib/mcollective/util/choria.rb
+++ b/lib/mcollective/util/choria.rb
@@ -369,6 +369,7 @@ module MCollective
 
           Puppet.settings.initialize_global_settings([])
           Puppet.settings.initialize_app_defaults(Puppet::Settings.app_defaults_for_run_mode(Puppet.run_mode))
+          Puppet.push_context(Puppet.base_context(Puppet.settings))
         end
 
         Puppet.settings[setting]


### PR DESCRIPTION
The initialization that was copied from the package agent was missing a
crucial piece leading to errors during provider initialization