### PR TITLE
(#92) Add a PQL node source

### DIFF
--- a/lib/mcollective/util/playbook/nodes.rb
+++ b/lib/mcollective/util/playbook/nodes.rb
@@ -1,4 +1,5 @@
 require_relative "nodes/mcollective_nodes"
+require_relative "nodes/pql_nodes"
 
 module MCollective
   module Util
@@ -169,7 +170,11 @@ module MCollective
         #
         # @node only MCollective nodes supported right now
         def resolver_for(type)
-          Nodes::McollectiveNodes.new
+          klass_name = "%sNodes" % type.capitalize
+
+          Nodes.const_get(klass_name).new
+        rescue NameError
+          raise("Cannot find a handler for Node Set type %s" % type)
         end
 
         def from_hash(data)

--- a/lib/mcollective/util/playbook/nodes/pql_nodes.rb
+++ b/lib/mcollective/util/playbook/nodes/pql_nodes.rb
@@ -1,0 +1,40 @@
+require "mcollective/util/choria"
+
+module MCollective
+  module Util
+    class Playbook
+      class Nodes
+        class PqlNodes
+          def initialize
+            @query = nil
+          end
+
+          def prepare; end
+
+          def validate_configuration!
+            raise("No PQL query specified") unless @query
+          end
+
+          def choria
+            @_choria ||= Util::Choria.new("production", nil, false)
+          end
+
+          # Initialize the nodes source from a hash
+          #
+          # @param data [Hash] input data matching nodes.json schema
+          # @return [PqlNodes]
+          def from_hash(data)
+            @query = data["query"]
+
+            self
+          end
+
+          # Performs the PQL query and extracts certnames
+          def discover
+            choria.pql_query(@query, true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/module/data/plugin.yaml
+++ b/module/data/plugin.yaml
@@ -20,6 +20,7 @@ mcollective_choria::client_files:
  - util/playbook/uses.rb
  - util/playbook/nodes
  - util/playbook/nodes/mcollective_nodes.rb
+ - util/playbook/nodes/pql_nodes.rb
  - util/playbook/inputs.rb
 mcollective_choria::common_directories:
   - util/choria

--- a/spec/unit/mcollective/discovery/choria_spec.rb
+++ b/spec/unit/mcollective/discovery/choria_spec.rb
@@ -15,17 +15,6 @@ module MCollective
       end
     end
 
-    describe "#query" do
-      it "should query and parse" do
-        discovery.choria.stubs(:facter_domain).returns("example.net")
-        discovery.choria.expects(:check_ssl_setup)
-        discovery.expects(:http_get).with("/pdb/query/v4?query=nodes+%7B+%7D").returns(get = stub)
-        discovery.https.expects(:request).with(get).returns([stub(:code => "200"), '{"rspec":1}'])
-
-        expect(discovery.query("nodes { }")).to eq("rspec" => 1)
-      end
-    end
-
     describe "#numeric?" do
       it "should correctly detect numbers" do
         expect(discovery.numeric?("100")).to be_truthy
@@ -39,20 +28,6 @@ module MCollective
         expect(
           discovery.node_search_string(["rspec1", "rspec2"])
         ).to eq("nodes[certname, deactivated] { (rspec1) and (rspec2) }")
-      end
-    end
-
-    describe "#extract_certs" do
-      it "should extract all certname fields" do
-        expect(
-          discovery.extract_certs([{"certname" => "one"}, {"certname" => "two"}, {"x" => "rspec"}])
-        ).to eq(["one", "two"])
-      end
-
-      it "should ignore deacivated nodes" do
-        expect(
-          discovery.extract_certs([{"certname" => "one", "deactivated" => "2016-09-12T18:57:51.700Z"}, {"certname" => "two"}])
-        ).to eq(["two"])
       end
     end
 

--- a/spec/unit/mcollective/util/playbook/nodes/pql_nodes_spec.rb
+++ b/spec/unit/mcollective/util/playbook/nodes/pql_nodes_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+require "mcollective/util/playbook"
+
+module MCollective
+  module Util
+    class Playbook
+      class Nodes
+        describe PqlNodes do
+          let(:pql) { PqlNodes.new }
+
+          describe "#discover" do
+            it "should search using choria" do
+              pql.from_hash("query" => "nodes {}")
+              pql.choria.expects(:pql_query).with("nodes {}", true).returns(["node1"])
+              expect(pql.discover).to eq(["node1"])
+            end
+          end
+
+          describe "#validate_configuration!" do
+            it "should not allow nil queries" do
+              expect { pql.validate_configuration! }.to raise_error("No PQL query specified")
+              pql.from_hash("query" => "nodes {}")
+              pql.validate_configuration!
+            end
+          end
+
+          describe "#from_hash" do
+            it "should save the query" do
+              pql.from_hash("query" => "nodes {}")
+              expect(pql.instance_variable_get("@query")).to eq("nodes {}")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/mcollective/util/playbook/nodes_spec.rb
+++ b/spec/unit/mcollective/util/playbook/nodes_spec.rb
@@ -9,6 +9,15 @@ module MCollective
         let(:nodes) { Nodes.new(playbook) }
         let(:playbook_fixture) { YAML.load(File.read("spec/fixtures/playbooks/playbook.yaml")) }
 
+        describe "#resolver_for" do
+          it "should get the right resolver" do
+            expect(nodes.resolver_for("mcollective")).to be_a(Nodes::McollectiveNodes)
+            expect(nodes.resolver_for("pql")).to be_a(Nodes::PqlNodes)
+
+            expect { nodes.resolver_for("rspec") }.to raise_error("Cannot find a handler for Node Set type rspec")
+          end
+        end
+
         describe "#from_hash" do
           it "should set up resolvers for each node set" do
             resolver = stub


### PR DESCRIPTION
Adds a node set source that take arbitrary PQL queries

Extracts the PQL functions from the choria discovery method into the
util class and reuse them here

```
nodes:
  country_servers:
    type: pql
    query: "facts { name = 'country' and value = '{{{ input.country }}}' }"
    test: true
    uses:
      - rpcutil
```