### PR TITLE
(#94) add a YAML discovery source

### DIFF
--- a/lib/mcollective/util/playbook/nodes.rb
+++ b/lib/mcollective/util/playbook/nodes.rb
@@ -1,5 +1,6 @@
 require_relative "nodes/mcollective_nodes"
 require_relative "nodes/pql_nodes"
+require_relative "nodes/yaml_nodes"
 
 module MCollective
   module Util

--- a/lib/mcollective/util/playbook/nodes/yaml_nodes.rb
+++ b/lib/mcollective/util/playbook/nodes/yaml_nodes.rb
@@ -1,0 +1,47 @@
+require "yaml"
+
+module MCollective
+  module Util
+    class Playbook
+      class Nodes
+        class YamlNodes
+          def initialize
+            @group = nil
+            @file = nil
+          end
+
+          def prepare; end
+
+          def validate_configuration!
+            raise("No node group YAML source file specified") unless @file
+            raise("Node group YAML source file %s is not readable" % @file) unless File.readable?(@file)
+            raise("No node group name specified") unless @group
+            raise("No data group %s defined in the data file %s" % [@group, @file]) unless data.include?(@group)
+            raise("Data group %s is not an array" % @group) unless data[@group].is_a?(Array)
+            raise("Data group %s is empty" % @group) if data[@group].empty?
+          end
+
+          # Initialize the nodes source from a hash
+          #
+          # @param data [Hash] input with `group` and `source` keys
+          # @return [PqlNodes]
+          def from_hash(data)
+            @group = data["group"]
+            @file = data["source"]
+
+            self
+          end
+
+          def data
+            @_data ||= YAML.load(File.read(@file))
+          end
+
+          # Performs the PQL query and extracts certnames
+          def discover
+            data[@group]
+          end
+        end
+      end
+    end
+  end
+end

--- a/module/data/plugin.yaml
+++ b/module/data/plugin.yaml
@@ -21,6 +21,7 @@ mcollective_choria::client_files:
  - util/playbook/nodes
  - util/playbook/nodes/mcollective_nodes.rb
  - util/playbook/nodes/pql_nodes.rb
+ - util/playbook/nodes/yaml_nodes.rb
  - util/playbook/inputs.rb
 mcollective_choria::common_directories:
   - util/choria

--- a/spec/fixtures/playbooks/nodes.yaml
+++ b/spec/fixtures/playbooks/nodes.yaml
@@ -1,0 +1,6 @@
+uk:
+  - node1.example.net
+  - node2.example.net
+  - node3.example.net
+non_array: foo
+empty_array: []

--- a/spec/unit/mcollective/util/playbook/nodes/yaml_nodes_spec.rb
+++ b/spec/unit/mcollective/util/playbook/nodes/yaml_nodes_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+require "mcollective/util/playbook"
+
+module MCollective
+  module Util
+    class Playbook
+      class Nodes
+        describe YamlNodes do
+          let(:nodes) { YamlNodes.new }
+          let(:fixture) { File.expand_path("spec/fixtures/playbooks/nodes.yaml") }
+
+          describe "#discover" do
+            it "should discover the right nodes" do
+              nodes.from_hash("group" => "uk", "source" => fixture)
+              expect(nodes.discover).to eq(["node1.example.net", "node2.example.net", "node3.example.net"])
+            end
+          end
+
+          describe "#data" do
+            it "should read and cache the file" do
+              nodes.from_hash("group" => "uk", "source" => fixture)
+              data = YAML.load(File.read(fixture))
+
+              expect(found = nodes.data).to eq(data)
+              expect(nodes.data).to be(found)
+            end
+          end
+
+          describe "#validate_configuration!" do
+            it "should detect good setups" do
+              nodes.from_hash("group" => "uk", "source" => fixture)
+              nodes.validate_configuration!
+            end
+
+            it "should detect no file set" do
+              expect { nodes.validate_configuration! }.to raise_error("No node group YAML source file specified")
+            end
+
+            it "should detect unreadable files" do
+              nodes.from_hash("source" => "/nonexisting")
+              expect { nodes.validate_configuration! }.to raise_error("Node group YAML source file /nonexisting is not readable")
+            end
+
+            it "should detect no group set" do
+              nodes.from_hash("source" => fixture)
+              expect { nodes.validate_configuration! }.to raise_error("No node group name specified")
+            end
+
+            it "should detect missing groups" do
+              nodes.from_hash("group" => "fr", "source" => fixture)
+              expect { nodes.validate_configuration! }.to raise_error("No data group fr defined in the data file %s" % fixture)
+            end
+
+            it "should detect non array data" do
+              nodes.from_hash("group" => "non_array", "source" => fixture)
+              expect { nodes.validate_configuration! }.to raise_error("Data group non_array is not an array")
+            end
+
+            it "should detect empty sets" do
+              nodes.from_hash("group" => "empty_array", "source" => fixture)
+              expect { nodes.validate_configuration! }.to raise_error("Data group empty_array is empty")
+            end
+          end
+
+          describe "#from_hash" do
+            it "should save the group and source" do
+              nodes.from_hash("group" => "uk", "source" => fixture)
+              expect(nodes.instance_variable_get("@group")).to eq("uk")
+              expect(nodes.instance_variable_get("@file")).to eq(fixture)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Given a YAML file like:

    uk:
      - node1.example.net
      - node2.example.net

You can construct a node set source like:

    nodes:
      country_servers:
        type: yaml
        source: /home/rip/nodes.yaml
        group: "{{{ input.country }}}"
        test: true
        uses:
          - rpcutil

Closes #94 