### PR TITLE
(#93) add a shell script node set source

### DIFF
--- a/lib/mcollective/util/playbook/nodes.rb
+++ b/lib/mcollective/util/playbook/nodes.rb
@@ -1,6 +1,7 @@
 require_relative "nodes/mcollective_nodes"
 require_relative "nodes/pql_nodes"
 require_relative "nodes/yaml_nodes"
+require_relative "nodes/shell_nodes"
 
 module MCollective
   module Util

--- a/lib/mcollective/util/playbook/nodes/shell_nodes.rb
+++ b/lib/mcollective/util/playbook/nodes/shell_nodes.rb
@@ -1,0 +1,47 @@
+module MCollective
+  module Util
+    class Playbook
+      class Nodes
+        class ShellNodes
+          def initialize
+            @script = nil
+          end
+
+          def prepare; end
+
+          def validate_configuration!
+            raise("No node source script specified") unless @script
+            raise("Node source script is not executable") unless File.executable?(@script)
+            raise("Node source script produced no results") if data.empty?
+          end
+
+          def from_hash(data)
+            @script = data["script"]
+
+            self
+          end
+
+          def valid_hostname?(host)
+            host =~ /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/
+          end
+
+          def data
+            return @_data if @_data
+
+            @_data = `#{@script}`.lines.map do |line|
+              line.chomp!
+
+              raise("%s is not a valid certname" % line) unless valid_hostname?(line)
+
+              line
+            end
+          end
+
+          def discover
+            data
+          end
+        end
+      end
+    end
+  end
+end

--- a/module/data/plugin.yaml
+++ b/module/data/plugin.yaml
@@ -22,6 +22,7 @@ mcollective_choria::client_files:
  - util/playbook/nodes/mcollective_nodes.rb
  - util/playbook/nodes/pql_nodes.rb
  - util/playbook/nodes/yaml_nodes.rb
+ - util/playbook/nodes/shell_nodes.rb
  - util/playbook/inputs.rb
 mcollective_choria::common_directories:
   - util/choria

--- a/spec/fixtures/playbooks/bad_script_nodes.sh
+++ b/spec/fixtures/playbooks/bad_script_nodes.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "node1 example.net"
+echo "node2 example.net"

--- a/spec/fixtures/playbooks/script_nodes.sh
+++ b/spec/fixtures/playbooks/script_nodes.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "node1.example.net"
+echo "node2.example.net"

--- a/spec/unit/mcollective/util/playbook/nodes/shell_nodes_spec.rb
+++ b/spec/unit/mcollective/util/playbook/nodes/shell_nodes_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+require "mcollective/util/playbook"
+
+module MCollective
+  module Util
+    class Playbook
+      class Nodes
+        describe ShellNodes do
+          let(:nodes) { ShellNodes.new }
+          let(:bad_fixture) { File.expand_path("spec/fixtures/playbooks/nodes.yaml") }
+          let(:fixture) { File.expand_path("spec/fixtures/playbooks/script_nodes.sh") }
+          let(:corrupt_fixture) { File.expand_path("spec/fixtures/playbooks/bad_script_nodes.sh") }
+
+          describe "#validate_configuration!" do
+            it "should allow good scenarios" do
+              nodes.from_hash("script" => fixture)
+              nodes.validate_configuration!
+            end
+
+            it "should detect no script set" do
+              expect { nodes.validate_configuration! }.to raise_error("No node source script specified")
+            end
+
+            it "should detect scripts that are not executable" do
+              nodes.from_hash("script" => bad_fixture)
+              expect { nodes.validate_configuration! }.to raise_error("Node source script is not executable")
+            end
+
+            it "should detect scripts that return no data" do
+              nodes.from_hash("script" => fixture)
+              nodes.expects(:data).returns([])
+              expect { nodes.validate_configuration! }.to raise_error("Node source script produced no results")
+            end
+          end
+
+          describe "#from_hash" do
+            it "should record the script path" do
+              nodes.from_hash("script" => fixture)
+              expect(nodes.instance_variable_get("@script")).to eq(fixture)
+            end
+          end
+
+          describe "#valid_certname?" do
+            it "should correctly detect certnames" do
+              expect(nodes.valid_hostname?("example.net")).to be_truthy
+              expect(nodes.valid_hostname?("node1 example.net")).to be_falsey
+            end
+          end
+
+          describe "#data" do
+            it "should detect corrupt data" do
+              nodes.from_hash("script" => corrupt_fixture)
+              expect { nodes.data }.to raise_error("node1 example.net is not a valid certname")
+            end
+          end
+
+          describe "#discover" do
+            it "should find all the nodes" do
+              nodes.from_hash("script" => fixture)
+              expect(nodes.discover).to eq(["node1.example.net", "node2.example.net"])
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows a shell script that produce one certname per line to be used
as node source

    nodes:
      country_servers:
        type: shell
        script: /home/rip/nodes.sh
        test: true
        uses:
          - rpcutil