### PR TITLE
(#95) Add a shell task

### DIFF
--- a/lib/mcollective/util/playbook/nodes.rb
+++ b/lib/mcollective/util/playbook/nodes.rb
@@ -95,7 +95,7 @@ module MCollective
             end
           end
 
-          @playbook.validate_agents(agent_nodes)
+          @playbook.validate_agents(agent_nodes) unless agent_nodes.empty?
         end
 
         # Determines if a nodeset needs connectivity test

--- a/lib/mcollective/util/playbook/tasks.rb
+++ b/lib/mcollective/util/playbook/tasks.rb
@@ -1,4 +1,5 @@
 require_relative "tasks/mcollective_task"
+require_relative "tasks/shell_task"
 
 module MCollective
   module Util
@@ -29,7 +30,11 @@ module MCollective
 
         # @todo support types of runner
         def runner_for(type)
-          Tasks::McollectiveTask.new
+          klass_name = "%sTask" % type.capitalize
+
+          Tasks.const_get(klass_name).new
+        rescue NameError
+          raise("Cannot find a handler for Task type %s" % type)
         end
 
         # Runs a specific task

--- a/lib/mcollective/util/playbook/tasks/shell_task.rb
+++ b/lib/mcollective/util/playbook/tasks/shell_task.rb
@@ -1,0 +1,75 @@
+module MCollective
+  module Util
+    class Playbook
+      class Tasks
+        class ShellTask
+          def validate_configuration!
+            raise("A command was not given") unless @command
+            raise("Nodes were given but is not an array") if @nodes && !@nodes.is_a?(Array)
+            raise("Nodes can not be empty") if @nodes.empty?
+          end
+
+          def from_hash(data)
+            @cwd = data["cwd"] || Dir.pwd
+            @timeout = data["timeout"]
+            @nodes = data["nodes"]
+            @environment = data["environment"]
+
+            if @nodes.is_a?(Array)
+              @command = "%s --nodes %s" % [data["command"], @nodes.join(",")]
+            else
+              @command = data["command"]
+            end
+
+            self
+          end
+
+          def shell_options
+            options = {}
+            options["cwd"] = @cwd if @cwd
+            options["timeout"] = Integer(@timeout) if @timeout
+            options["environment"] = @environment if @environment
+            options["stdout"] = []
+            options["stderr"] = options["stdout"]
+            options
+          end
+
+          def run
+            if @nodes
+              Log.info("Starting command %s against %d nodes" % [@command, @nodes.size])
+            else
+              Log.info("Starting command %s" % [@command])
+            end
+
+            begin
+              options = shell_options
+
+              shell = Shell.new(@command, options)
+              shell.runcommand
+
+              options["stdout"].each do |output|
+                output.lines.each do |line|
+                  Log.info(line.chomp)
+                end
+              end
+
+              if shell.status.exitstatus == 0
+                Log.info("Successfully ran command %s" % [@command])
+                [true, "Command completed successfully", options["stdout"]]
+              else
+                Log.warn("Failed to run command %s with exit code %s" % [@command, shell.status.exitstatus])
+                [false, "Command failed with code %d" % [shell.status.exitstatus], options["stdout"]]
+              end
+            rescue
+              msg = "Could not create request for %s#%s: %s: %s" % [@agent, @action, $!.class, $!.to_s]
+              Log.debug(msg)
+              Log.debug($!.backtrace.join("\t\n"))
+
+              [false, msg, []]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/mcollective/util/playbook/tasks/mcollective_task_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks/mcollective_task_spec.rb
@@ -1,0 +1,209 @@
+require "spec_helper"
+require "mcollective/util/playbook"
+
+module MCollective
+  module Util
+    class Playbook
+      class Tasks
+        describe McollectiveTask do
+          let(:task) { McollectiveTask.new }
+
+          describe "#run" do
+            before(:each) do
+              task.from_hash(
+                "nodes" => ["node1", "node2"],
+                "action" => "puppet.disable",
+                "batch_size" => 10,
+                "description" => "disable puppet",
+                "post" => ["summarize"],
+                "silent" => false,
+                "properties" => {
+                  :message => "rspec"
+                }
+              )
+            end
+
+            it "should run correctly" do
+              result_data = {
+                :agent => "puppet",
+                :action => "disable",
+                :sender => "example.net",
+                :statuscode => 0,
+                :statusmsg => "OK",
+                :data => {
+                  :status => "Succesfully locked the Puppet agent: Disabled via MCollective by choria=rip.mcollective at 2016-12-25 07:59",
+                  :enabled => false
+                }
+              }
+
+              rpc_result1 = RPC::Result.new("puppet", "disable", result_data)
+              rpc_result2 = RPC::Result.new("puppet", "disable", result_data)
+
+              task.stubs(:client).returns(mc_client = stub)
+              mc_client.stubs(:stats).returns(mc_stats = stub(:requestid => "123"))
+              mc_client.expects(:disable).with(:message => "rspec").multiple_yields([[:x, rpc_result1]], [[:x, rpc_result2]])
+
+              task.expects(:log_reply).with(rpc_result1)
+              task.expects(:log_reply).with(rpc_result2)
+              task.expects(:log_summarize).with(mc_stats)
+              task.expects(:log_results).with(mc_stats, [rpc_result1, rpc_result2])
+              task.expects(:run_result).with(mc_stats, [rpc_result1, rpc_result2])
+              task.run
+            end
+
+            it "should fail gracefully" do
+              task.expects(:client).raises("rspec failure")
+              expect(task.run).to eq([false, "Could not create request for puppet#disable: RuntimeError: rspec failure", []])
+            end
+          end
+
+          describe "#request_success?" do
+            it "should correctly determine succesful requests" do
+              expect(task.request_success?(stub(:failcount => 0, :okcount => 1, :noresponsefrom => []))).to be(true)
+              expect(task.request_success?(stub(:failcount => 1, :okcount => 1, :noresponsefrom => []))).to be(false)
+              expect(task.request_success?(stub(:failcount => 0, :okcount => 0, :noresponsefrom => []))).to be(false)
+              expect(task.request_success?(stub(:failcount => 0, :okcount => 0, :noresponsefrom => ["node1"]))).to be(false)
+            end
+          end
+
+          describe "#run_result" do
+            let(:result_data) do
+              {
+                :agent => "puppet",
+                :action => "disable",
+                :sender => "example.net",
+                :statuscode => 0,
+                :statusmsg => "OK",
+                :data => {
+                  :status => "Succesfully locked the Puppet agent: Disabled via MCollective by choria=rip.mcollective at 2016-12-25 07:59",
+                  :enabled => false
+                }
+              }
+            end
+            let(:rpc_result) { RPC::Result.new("puppet", "disable", result_data) }
+
+            before(:each) do
+              task.instance_variable_set("@agent", "puppet")
+              task.instance_variable_set("@action", "disable")
+            end
+
+            it "should create a correct fail result set" do
+              stats = stub(:requestid => "123", :failcount => 1, :noresponsefrom => [], :okcount => 0)
+
+              expect(task.run_result(stats, [rpc_result])).to eq(
+                [
+                  false,
+                  "Failed request 123 for puppet#disable on 1 failed node(s)",
+                  [
+                    {
+                      "agent" => "puppet",
+                      "action" => "disable",
+                      "sender" => "example.net",
+                      "statuscode" => 0,
+                      "statusmsg" => "OK",
+                      "data" => result_data[:data],
+                      "requestid" => "123"
+                    }
+                  ]
+                ]
+              )
+            end
+
+            it "should create a correct success result set" do
+              stats = stub(:requestid => "123", :failcount => 0, :noresponsefrom => [], :okcount => 1)
+
+              expect(task.run_result(stats, [rpc_result])).to eq(
+                [
+                  true,
+                  "Successful request 123 for puppet#disable on 1 node(s)",
+                  [
+                    {
+                      "agent" => "puppet",
+                      "action" => "disable",
+                      "sender" => "example.net",
+                      "statuscode" => 0,
+                      "statusmsg" => "OK",
+                      "data" => result_data[:data],
+                      "requestid" => "123"
+                    }
+                  ]
+                ]
+              )
+            end
+          end
+
+          describe "#from_hash" do
+            it "should initialize correctly" do
+              task.from_hash(
+                "nodes" => ["node1", "node2"],
+                "action" => "puppet.disable",
+                "batch_size" => 10,
+                "description" => "disable puppet",
+                "post" => ["summarize"],
+                "silent" => false,
+                "properties" => {
+                  :message => "rspec"
+                }
+              )
+
+              expect(task.instance_variable_get("@nodes")).to eq(["node1", "node2"])
+              expect(task.instance_variable_get("@agent")).to eq("puppet")
+              expect(task.instance_variable_get("@action")).to eq("disable")
+              expect(task.instance_variable_get("@batch_size")).to eq(10)
+              expect(task.instance_variable_get("@description")).to eq("disable puppet")
+              expect(task.instance_variable_get("@post")).to eq(["summarize"])
+              expect(task.instance_variable_get("@log_replies")).to eq(true)
+              expect(task.instance_variable_get("@properties")).to eq(:message => "rspec")
+            end
+          end
+
+          describe "#parse_action" do
+            it "should parse agent and action" do
+              expect(task.parse_action("puppet.enable")).to eq(["puppet", "enable"])
+            end
+          end
+
+          describe "#validate_configuration!" do
+            it "should not support unbounded node lists" do
+              expect { task.validate_configuration! }.to raise_error("Nodes need to be supplied, refusing to run against empty node list")
+
+              task.instance_variable_get("@nodes") << "node1"
+              task.validate_configuration!
+            end
+          end
+
+          describe "#create_and_configure_client" do
+            before(:each) do
+              Util.stubs(:config_file_for_user).returns("/nonexisting/client.cfg")
+            end
+
+            it "should create a client" do
+              RPC::Client.expects(:new).with("rspec", :configfile => "/nonexisting/client.cfg").returns(client = stub)
+              task.instance_variable_set("@agent", "rspec")
+              task.instance_variable_set("@batch_size", 10)
+              task.instance_variable_set("@nodes", ["node1", "node2"])
+              client.expects(:progress=).with(false)
+              client.expects(:batch_size=).with(10)
+              client.expects(:discover).with(:nodes => ["node1", "node2"])
+              expect(task.create_and_configure_client).to be(client)
+            end
+          end
+
+          describe "#client" do
+            it "should make a client and cache it by default" do
+              task.expects(:create_and_configure_client).returns(c = stub)
+              expect(task.client).to be(c)
+              expect(task.client).to be(c)
+            end
+
+            it "should support always making a client" do
+              task.expects(:create_and_configure_client).returns(c1 = stub, c2 = stub).twice
+              expect(task.client(false)).to be(c1)
+              expect(task.client(false)).to be(c2)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/mcollective/util/playbook/tasks/shell_task_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks/shell_task_spec.rb
@@ -1,0 +1,106 @@
+require "spec_helper"
+require "mcollective/util/playbook"
+
+module MCollective
+  module Util
+    class Playbook
+      class Tasks
+        describe ShellTask do
+          let(:task) { ShellTask.new }
+
+          describe "#run" do
+            it "should detect failed scripts" do
+              task.from_hash("command" => "/tmp/x.sh")
+              Shell.expects(:new).with("/tmp/x.sh", "cwd" => Dir.pwd, "stdout" => [], "stderr" => []).returns(shell = stub)
+
+              shell.expects(:runcommand)
+              shell.stubs(:status).returns(stub(:exitstatus => 1))
+
+              expect(task.run).to eq([false, "Command failed with code 1", []])
+            end
+
+            it "should detect successfull scripts" do
+              task.from_hash("command" => "/tmp/x.sh")
+              Shell.expects(:new).with("/tmp/x.sh", "cwd" => Dir.pwd, "stdout" => [], "stderr" => []).returns(shell = stub)
+
+              shell.expects(:runcommand)
+              shell.stubs(:status).returns(stub(:exitstatus => 0))
+
+              expect(task.run).to eq([true, "Command completed successfully", []])
+            end
+          end
+
+          describe "#shell_options" do
+            it "should construct correct options" do
+              task.from_hash(
+                "command" => "/tmp/x.sh",
+                "cwd" => "/tmp",
+                "timeout" => 10,
+                "environment" => {
+                  "FOO" => "BAR"
+                }
+              )
+
+              expect(task.shell_options).to eq(
+                "cwd" => "/tmp",
+                "timeout" => 10,
+                "stdout" => [],
+                "stderr" => [],
+                "environment" => {
+                  "FOO" => "BAR"
+                }
+              )
+            end
+          end
+
+          describe "#validate_configuration!" do
+            it "should expect a command" do
+              expect { task.validate_configuration! }.to raise_error("A command was not given")
+            end
+
+            it "should validate nodes" do
+              task.from_hash(
+                "command" => "/tmp/x.sh",
+                "nodes" => 1
+              )
+              expect { task.validate_configuration! }.to raise_error("Nodes were given but is not an array")
+
+              task.from_hash(
+                "command" => "/tmp/x.sh",
+                "nodes" => []
+              )
+              expect { task.validate_configuration! }.to raise_error("Nodes can not be empty")
+            end
+          end
+
+          describe "#from_hash" do
+            it "should parse correctly" do
+              task.from_hash(
+                "command" => "/tmp/x.sh",
+                "cwd" => "/tmp",
+                "timeout" => 10,
+                "environment" => {
+                  "FOO" => "BAR"
+                }
+              )
+
+              expect(task.instance_variable_get("@command")).to eq("/tmp/x.sh")
+              expect(task.instance_variable_get("@cwd")).to eq("/tmp")
+              expect(task.instance_variable_get("@timeout")).to eq(10)
+              expect(task.instance_variable_get("@environment")).to eq(
+                "FOO" => "BAR"
+              )
+
+              task.from_hash(
+                "command" => "/tmp/x.sh",
+                "nodes" => ["node1", "node2"]
+              )
+
+              expect(task.instance_variable_get("@command")).to eq("/tmp/x.sh --nodes node1,node2")
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Runs shell commands with nodes support

    tasks:
      - shell:
          description: Shell test
          command: "/home/rip/test.sh"
          cwd: "/tmp"
          nodes: "{{{ nodes.test_servers }}}"
          environment:
            "HELLO": "WORLD"

This will run test.sh --nodes node1,node2

Closes #95 