### PR TITLE
(#102) support arguments to scripts used in shell nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2016/12/26|102   |Support arguments to commands ran by the shell node set in playbooks                                     |
 |2016/12/26|      |Release 0.0.12                                                                                           |
 |2016/12/26|104   |Support posting messages to slack as a task step                                                         |
 |2016/12/25|95    |Support running shell commands as task steps                                                             |

--- a/lib/mcollective/util/playbook/nodes.rb
+++ b/lib/mcollective/util/playbook/nodes.rb
@@ -79,7 +79,7 @@ module MCollective
         def resolve_nodes(node_set)
           node_props = @nodes[node_set]
           node_props[:resolver].prepare
-          node_props[:discovered] = node_props[:resolver].discover
+          node_props[:discovered] = node_props[:resolver].discover.uniq
         end
 
         # Checks if the agents on the nodes matches the desired versions

--- a/spec/unit/mcollective/util/playbook/nodes/shell_nodes_spec.rb
+++ b/spec/unit/mcollective/util/playbook/nodes/shell_nodes_spec.rb
@@ -50,7 +50,15 @@ module MCollective
           describe "#data" do
             it "should detect corrupt data" do
               nodes.from_hash("script" => corrupt_fixture)
-              expect { nodes.data }.to raise_error("node1 example.net is not a valid certname")
+              expect { nodes.data }.to raise_error("node1 example.net is not a valid hostname")
+            end
+
+            it "should only accept outputs that exit with status 0" do
+              nodes.from_hash("script" => "echo 'example.net';exit 0")
+              expect(nodes.data).to eq(["example.net"])
+
+              nodes.from_hash("script" => "echo 'example.net';exit 1")
+              expect { nodes.data }.to raise_error("Could not disocver nodes via shell method, command exited with code 1")
             end
           end
 

--- a/spec/unit/mcollective/util/playbook/nodes_spec.rb
+++ b/spec/unit/mcollective/util/playbook/nodes_spec.rb
@@ -133,7 +133,7 @@ module MCollective
             seq = sequence(:nodes)
             resolver = nodes.nodes["load_balancers"][:resolver]
             resolver.expects(:prepare).in_sequence(seq)
-            resolver.expects(:discover).in_sequence(seq).returns(["rspec1", "rspec2"])
+            resolver.expects(:discover).in_sequence(seq).returns(["rspec1", "rspec2", "rspec1"])
 
             nodes.resolve_nodes("load_balancers")
 


### PR DESCRIPTION
Now uses the M::Shell system to run the commands and additionally checks
for exit code 0, only accepts STDOUT specifically

Closes #102 