### PR TITLE
(#109) Add a mcollective_assert task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -137,3 +137,6 @@ Metrics/BlockLength:
 
 Performance/Casecmp:
   Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/lib/mcollective/util/playbook/tasks.rb
+++ b/lib/mcollective/util/playbook/tasks.rb
@@ -1,4 +1,5 @@
 require_relative "tasks/mcollective_task"
+require_relative "tasks/mcollective_assert_task"
 require_relative "tasks/shell_task"
 require_relative "tasks/slack_task"
 
@@ -47,7 +48,7 @@ module MCollective
           properties = task[:properties]
           success = false
 
-          Log.info("About to run task: %s" % properties["description"])
+          Log.info("About to run task: %s" % properties["description"]) if properties["description"]
 
           if hooks && !run_set("pre_task")
             Log.warn("Failing task because a critical pre_task hook failed")

--- a/lib/mcollective/util/playbook/tasks/mcollective_assert_task.rb
+++ b/lib/mcollective/util/playbook/tasks/mcollective_assert_task.rb
@@ -1,0 +1,125 @@
+module MCollective
+  module Util
+    class Playbook
+      class Tasks
+        class Mcollective_assertTask
+          def initialize
+            @properties = {}
+            @nodes = []
+            @action = nil
+            @pre_sleep = 10
+            @expression = []
+            @pre_slept = false
+            @description = nil
+          end
+
+          def from_hash(data)
+            @nodes = data.fetch("nodes", [])
+            @action = data["action"]
+            @properties = data.fetch("properties", {})
+            @pre_sleep = Integer(data.fetch("pre_sleep", 10))
+            @expression = data["expression"] || []
+            @description = data.fetch("description", "Wait until %s matches %s %s %s" % [@action, @expression[0], @expression[1], @expression[2]])
+
+            self
+          end
+
+          def validate_configuration!
+            raise("An expression should be 3 items exactly") unless @expression.size == 3
+          end
+
+          def perform_pre_sleep
+            return if @pre_slept || @pre_sleep <= 0
+
+            Log.info("Sleeping %d seconds before check" % [@pre_sleep])
+
+            sleep(@pre_sleep)
+
+            @pre_slept = true
+          end
+
+          def mcollective_task
+            rpc = Tasks::McollectiveTask.new
+            rpc.from_hash(
+              "description" => @description,
+              "nodes" => @nodes,
+              "action" => @action,
+              "properties" => @properties,
+              "silent" => true
+            )
+          end
+
+          def evaluate(left, operator, right)
+            invert = false
+
+            if operator =~ /^\!\s*(.+)/
+              invert = true
+              operator = $1
+            end
+
+            result = case operator
+                     when "<"
+                       left < right
+                     when ">"
+                       left > right
+                     when ">="
+                       left >= right
+                     when "<="
+                       left <= right
+                     when "==", "="
+                       left == right
+                     when "=~"
+                       !!Regexp.new(right, true).match(left)
+                     when "in"
+                       right.include?(left)
+                     else
+                       raise("Unknown operator %s encountered, cannot assert state" % operator)
+                     end
+
+            invert ? !result : result
+          end
+
+          def check_results(results)
+            left, operator, right = @expression
+            failed = false
+
+            results.each do |result|
+              unless result["data"].include?(left)
+                Log.warn("Result from %s does not have the %s item" % [result["sender"], left])
+                failed = true
+                next
+              end
+
+              unless evaluate(result["data"][left], operator, right)
+                Log.warn("Result from %s does not match the expression" % [result["sender"]])
+                failed = true
+              end
+            end
+
+            if failed
+              [false, "Not all nodes matched expression %s %s %s" % [left, operator, right], results]
+            else
+              [true, "All nodes matched expression %s %s %s" % [left, operator, right], results]
+            end
+          end
+
+          def run
+            perform_pre_sleep
+
+            success, msg, results = mcollective_task.run
+
+            return([false, "Request %s failed: %s" % [@action, msg], []]) unless success
+
+            check_results(results)
+          rescue
+            msg = "Could not create request for %s: %s: %s" % [@action, $!.class, $!.to_s]
+            Log.debug(msg)
+            Log.debug($!.backtrace.join("\t\n"))
+
+            [false, msg, []]
+          end
+        end
+      end
+    end
+  end
+end

--- a/module/data/plugin.yaml
+++ b/module/data/plugin.yaml
@@ -16,6 +16,7 @@ mcollective_choria::client_files:
  - util/playbook/tasks/mcollective_task.rb
  - util/playbook/tasks/shell_task.rb
  - util/playbook/tasks/slack_task.rb
+ - util/playbook/tasks/mcollective_assert_task.rb
  - util/playbook/tasks.rb
  - util/playbook/nodes.rb
  - util/playbook/template_util.rb

--- a/spec/unit/mcollective/util/natswrapper_spec.rb
+++ b/spec/unit/mcollective/util/natswrapper_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-
 require "mcollective/util/natswrapper"
 
 module MCollective

--- a/spec/unit/mcollective/util/playbook/tasks/mcollective_assert_task_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks/mcollective_assert_task_spec.rb
@@ -1,0 +1,195 @@
+require "spec_helper"
+require "mcollective/util/playbook"
+
+module MCollective
+  module Util
+    class Playbook
+      class Tasks
+        describe Mcollective_assertTask do
+          let(:task) { Mcollective_assertTask.new }
+
+          before(:each) do
+            task.from_hash(
+              "nodes" => ["node1", "node2"],
+              "action" => "puppet.status",
+              "pre_sleep" => 10,
+              "description" => "test description",
+              "expression" => [:idling, "==", true],
+              "properties" => {"prop" => "rspec"}
+            )
+          end
+
+          describe "#run" do
+            it "should fail if the check fails" do
+              task.stubs(:mcollective_task).returns(mct = stub)
+              task.stubs(:perform_pre_sleep)
+              mct.stubs(:run).returns([true, "ok", [{"data" => {:idling => true}, "sender" => "rspec1"}]])
+              task.expects(:check_results).with([{"data" => {:idling => true}, "sender" => "rspec1"}]).returns([true, "rspec", []])
+
+              expect(task.run).to eq([true, "rspec", []])
+            end
+
+            it "should fail if the run failed" do
+              task.stubs(:mcollective_task).returns(mct = stub)
+
+              seq = sequence(:s)
+              task.expects(:perform_pre_sleep).in_sequence(seq)
+              mct.expects(:run).in_sequence(seq).returns([false, "rspec", []])
+              expect(task.run).to eq([false, "Request puppet.status failed: rspec", []])
+            end
+          end
+
+          describe "#check_results" do
+            it "should detect matching results" do
+              results = [
+                {"data" => {:idling => true}, "sender" => "rspec1"},
+                {"data" => {:idling => true}, "sender" => "rspec2"}
+              ]
+
+              expect(task.check_results(results)).to eq([true, "All nodes matched expression idling == true", results])
+            end
+
+            it "should detect evaluation failed items" do
+              Log.expects(:warn).with("Result from rspec2 does not match the expression")
+              results = [
+                {"data" => {:idling => true}, "sender" => "rspec1"},
+                {"data" => {:idling => false}, "sender" => "rspec2"}
+              ]
+
+              expect(task.check_results(results)).to eq([false, "Not all nodes matched expression idling == true", results])
+            end
+
+            it "should detect missing data items" do
+              Log.expects(:warn).with("Result from rspec1 does not have the idling item")
+              Log.expects(:warn).with("Result from rspec2 does not have the idling item")
+              task.expects(:evaluate).never
+
+              results = [
+                {"data" => {}, "sender" => "rspec1"},
+                {"data" => {}, "sender" => "rspec2"}
+              ]
+
+              expect(task.check_results(results)).to eq([false, "Not all nodes matched expression idling == true", results])
+            end
+          end
+
+          describe "#evaluate" do
+            it "should support in" do
+              expect(task.evaluate("foo", "in", ["foo", "bar"])).to be(true)
+              expect(task.evaluate("foo", "in", ["bar", "bar"])).to be(false)
+              expect(task.evaluate("foo", "!in", ["bar", "bar"])).to be(true)
+            end
+
+            it "should support =~" do
+              expect(task.evaluate("foo", "=~", "o")).to be(true)
+              expect(task.evaluate("FOO", "=~", "o")).to be(true)
+              expect(task.evaluate("FOO", "=~", "a")).to be(false)
+              expect(task.evaluate("foo", "=~", "a")).to be(false)
+              expect(task.evaluate("foo", "!=~", "a")).to be(true)
+            end
+
+            it "should support ==" do
+              expect(task.evaluate("1", "==", "1")).to be(true)
+              expect(task.evaluate("1", "=", "1")).to be(true)
+              expect(task.evaluate("1", "==", "2")).to be(false)
+              expect(task.evaluate("1", "=", "2")).to be(false)
+              expect(task.evaluate("1", "!=", "2")).to be(true)
+              expect(task.evaluate("1", "!==", "2")).to be(true)
+            end
+
+            it "should support <" do
+              [["a", "b"], [1, 2]].each do |left, right|
+                expect(task.evaluate(left, "<", right)).to be(true)
+              end
+
+              [["b", "a"], [2, 1], [1, 1], ["a", "a"]].each do |left, right|
+                expect(task.evaluate(left, "<", right)).to be(false)
+              end
+
+              expect(task.evaluate("a", "!<", "b")).to be(false)
+            end
+
+            it "should support >" do
+              [["a", "b"], [1, 2], [1, 1], ["a", "a"]].each do |left, right|
+                expect(task.evaluate(left, ">", right)).to be(false)
+              end
+
+              [["b", "a"], [2, 1]].each do |left, right|
+                expect(task.evaluate(left, ">", right)).to be(true)
+              end
+
+              expect(task.evaluate("a", "!>", "b")).to be(true)
+            end
+
+            it "should support >=" do
+              [["b", "a"], [2, 1]].each do |left, right|
+                expect(task.evaluate(left, ">=", right)).to be(true)
+              end
+
+              [["a", "b"], [1, 2]].each do |left, right|
+                expect(task.evaluate(left, ">=", right)).to be(false)
+              end
+
+              expect(task.evaluate("a", "!>=", "a")).to be(false)
+            end
+
+            it "should support <=" do
+              [["b", "a"], [2, 1]].each do |left, right|
+                expect(task.evaluate(left, "<=", right)).to be(false)
+              end
+
+              [["a", "b"], [1, 2], [1, 1], ["a", "a"]].each do |left, right|
+                expect(task.evaluate(left, "<=", right)).to be(true)
+              end
+
+              expect(task.evaluate("a", "!<=", "a")).to be(false)
+            end
+          end
+
+          describe "#mcollective_task" do
+            it "should configure the task correctly" do
+              Tasks::McollectiveTask.expects(:new).returns(mct = stub)
+
+              mct.expects(:from_hash).with(
+                "description" => "test description",
+                "nodes" => ["node1", "node2"],
+                "action" => "puppet.status",
+                "properties" => {"prop" => "rspec"},
+                "silent" => true
+              )
+
+              task.mcollective_task
+            end
+          end
+
+          describe "#perform_pre_sleep" do
+            it "should sleep once only" do
+              task.from_hash("pre_sleep" => 1)
+              task.expects(:sleep).with(1).once
+              task.perform_pre_sleep
+              task.perform_pre_sleep
+              task.perform_pre_sleep
+            end
+          end
+
+          describe "#validate_configuration!" do
+            it "should detect invalid expressions" do
+              task.from_hash("expression" => nil)
+              expect { task.validate_configuration! }.to raise_error("An expression should be 3 items exactly")
+            end
+          end
+
+          describe "#from_hash" do
+            it "should hold correct values" do
+              expect(task.instance_variable_get("@nodes")).to eq(["node1", "node2"])
+              expect(task.instance_variable_get("@action")).to eq("puppet.status")
+              expect(task.instance_variable_get("@pre_sleep")).to eq(10)
+              expect(task.instance_variable_get("@expression")).to eq([:idling, "==", true])
+              expect(task.instance_variable_get("@description")).to eq("test description")
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
To solve the problem where for instance you disable Puppet and want to
wait for any runs to finish and all the disabled ones to go idle before
making changes to your site ideally we'd have some form of macro in
MCollective

In the mean time though a mcollective_assert task is added that can be
used to achieve this:

    - mcollective_assert:
        description: Wait for Puppet to go idle
        action: puppet.status
        nodes: "{{{ nodes.dev }}}"
        expression:
          - :idling
          - "=="
          - true
        pre_sleep: 0
        tries: 10
        try_sleep: 30

The assert fails when it's not idlng and the combination of the tries
and try_sleep gets the desired wait behaviour