### PR TITLE
(#96) add a webhook task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2016/12/28|96    |Add a webhook task used to GET and POST to other systems                                                 |
+|2016/12/27|109   |Add a mcollective_assert task used to check or wait for certain states                                   |
 |2016/12/26|102   |Support arguments to commands ran by the shell node set in playbooks                                     |
 |2016/12/26|      |Release 0.0.12                                                                                           |
 |2016/12/26|104   |Support posting messages to slack as a task step                                                         |

--- a/lib/mcollective/util/choria.rb
+++ b/lib/mcollective/util/choria.rb
@@ -189,12 +189,14 @@ module MCollective
         http
       end
 
-      # Creates a JSON accepting Net::HTTP::Get instance for a path
+      # Creates a Net::HTTP::Get instance for a path that defaults to accepting JSON
       #
       # @param path [String]
       # @return [Net::HTTP::Get]
-      def http_get(path)
-        Net::HTTP::Get.new(path, "Accept" => "application/json")
+      def http_get(path, headers=nil)
+        headers ||= {"Accept" => "application/json"}
+
+        Net::HTTP::Get.new(path, headers)
       end
 
       # Extract certnames from PQL results, deactivated nodes are ignored
@@ -588,7 +590,7 @@ module MCollective
 
         server = puppetca_server
 
-        req = Net::HTTP::Get.new("/puppet-ca/v1/certificate/ca", "Content-Type" => "text/plain")
+        req = http_get("/puppet-ca/v1/certificate/ca", "Content-Type" => "text/plain")
         resp, _ = https(server).request(req)
 
         if resp.code == "200"
@@ -630,7 +632,7 @@ module MCollective
       def attempt_fetch_cert
         return true if has_client_public_cert?
 
-        req = Net::HTTP::Get.new("/puppet-ca/v1/certificate/%s" % certname, "Accept" => "text/plain")
+        req = http_get("/puppet-ca/v1/certificate/%s" % certname, "Accept" => "text/plain")
         resp, _ = https(puppetca_server).request(req)
 
         if resp.code == "200"

--- a/lib/mcollective/util/playbook/tasks.rb
+++ b/lib/mcollective/util/playbook/tasks.rb
@@ -2,6 +2,7 @@ require_relative "tasks/mcollective_task"
 require_relative "tasks/mcollective_assert_task"
 require_relative "tasks/shell_task"
 require_relative "tasks/slack_task"
+require_relative "tasks/webhook_task"
 
 module MCollective
   module Util

--- a/lib/mcollective/util/playbook/tasks/webhook_task.rb
+++ b/lib/mcollective/util/playbook/tasks/webhook_task.rb
@@ -1,0 +1,96 @@
+require "uri"
+require "json"
+
+module MCollective
+  module Util
+    class Playbook
+      class Tasks
+        class WebhookTask
+          USER_AGENT = "Choria Playbooks http://choria.io".freeze
+
+          def validate_configuration!
+            raise("A uri is required") unless @uri
+            raise("Only GET and POST is supported as methods") unless ["GET", "POST"].include?(@method)
+          end
+
+          def from_hash(data)
+            @headers = data.fetch("headers", {})
+            @data = data.fetch("data", {})
+            @uri = data["uri"]
+            @method = data.fetch("method", "POST").upcase
+
+            self
+          end
+
+          def create_uri
+            uri = URI.parse(@uri)
+
+            if @method == "GET"
+              query = Array(uri.query)
+
+              @data.each do |k, v|
+                query << "%s=%s" % [URI.escape(k), URI.escape(v.to_s)]
+              end
+
+              uri.query = query.join("&") unless query.empty?
+            end
+
+            uri
+          end
+
+          def http_get_request(uri)
+            headers = {
+              "User-Agent" => USER_AGENT
+            }.merge(@headers)
+
+            Net::HTTP::Get.new(uri.request_uri, headers)
+          end
+
+          def http_post_request(uri)
+            headers = {
+              "Content-Type" => "application/json",
+              "User-Agent" => USER_AGENT
+            }.merge(@headers)
+
+            req = Net::HTTP::Post.new(uri.request_uri, headers)
+            req.body = @data.to_json
+            req
+          end
+
+          def http_request(uri)
+            return http_get_request(uri) if @method == "GET"
+            return http_post_request(uri) if @method == "POST"
+            raise("Unknown request method %s" % @method)
+          end
+
+          def choria
+            @_choria ||= Util::Choria.new("production", nil, false)
+          end
+
+          def run
+            uri = create_uri
+
+            http = choria.https(:target => uri.host, :port => uri.port)
+            http.use_ssl = false if uri.scheme == "http"
+
+            resp = http.request(http_request(uri))
+
+            Log.debug("%s request to %s returned code %s with body: %s" % [@method, uri.to_s, resp.code, resp.body])
+
+            if resp.code == "200"
+              [true, "Successfully sent %s request to webhook %s" % [@method, @uri], [resp.body]]
+            else
+              [false, "Failed to send %s request to webhook %s: %s: %s" % [@method, @uri, resp.code, resp.body], [resp.body]]
+            end
+          rescue
+            msg = "Could not send %s to webhook %s: %s: %s" % [@method, @uri, $!.class, $!.to_s]
+            Log.debug(msg)
+            Log.debug($!.backtrace.join("\t\n"))
+
+            [false, msg, []]
+          end
+        end
+      end
+    end
+  end
+end

--- a/module/data/plugin.yaml
+++ b/module/data/plugin.yaml
@@ -17,6 +17,7 @@ mcollective_choria::client_files:
  - util/playbook/tasks/shell_task.rb
  - util/playbook/tasks/slack_task.rb
  - util/playbook/tasks/mcollective_assert_task.rb
+ - util/playbook/tasks/webhook_task.rb
  - util/playbook/tasks.rb
  - util/playbook/nodes.rb
  - util/playbook/template_util.rb

--- a/spec/unit/mcollective/util/playbook/tasks/webhook_task_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks/webhook_task_spec.rb
@@ -1,0 +1,97 @@
+require "spec_helper"
+require "mcollective/util/playbook"
+
+module MCollective
+  module Util
+    class Playbook
+      class Tasks
+        describe WebhookTask do
+          let(:task) { WebhookTask.new }
+
+          before(:each) do
+            task.from_hash(
+              "headers" => {"X-Header" => "x_value"},
+              "data" => {"rspec1" => 1, "rspec2" => 2},
+              "uri" => "http://localhost/rspec?foo=bar",
+              "method" => "POST"
+            )
+          end
+
+          describe "#run" do
+            it "should handle 200 as success" do
+              task.expects(:choria).returns(choria = stub)
+              choria.expects(:https).with(:target => "localhost", :port => 80).returns(http = stub)
+              http.expects(:use_ssl=).with(false)
+              http.expects(:request).returns(stub(:code => "200", :body => "ok"))
+              expect(task.run).to eq([true, "Successfully sent POST request to webhook http://localhost/rspec?foo=bar", ["ok"]])
+            end
+
+            it "should handle !200 as failure" do
+              task.expects(:choria).returns(choria = stub)
+              choria.expects(:https).with(:target => "localhost", :port => 80).returns(http = stub)
+              http.expects(:use_ssl=).with(false)
+              http.expects(:request).returns(stub(:code => "404", :body => "not found"))
+              expect(task.run).to eq([false, "Failed to send POST request to webhook http://localhost/rspec?foo=bar: 404: not found", ["not found"]])
+            end
+          end
+
+          describe "#http_request" do
+            it "should invoke the right method" do
+              task.instance_variable_set("@method", "GET")
+              task.expects(:http_get_request).with(:rspec).returns(:rspec)
+              expect(task.http_request(:rspec)).to eq(:rspec)
+
+              task.instance_variable_set("@method", "POST")
+              task.expects(:http_post_request).with(:rspec).returns(:rspec)
+              expect(task.http_request(:rspec)).to eq(:rspec)
+
+              task.instance_variable_set("@method", "RSPEC")
+              task.expects(:http_get_request).never
+              task.expects(:http_post_request).never
+              expect { task.http_request(:rspec) }.to raise_error("Unknown request method RSPEC")
+            end
+          end
+
+          describe "#http_post_request" do
+            it "should create the right request" do
+              uri = task.create_uri
+              post = stub(:https)
+
+              Net::HTTP::Post.expects(:new).with(
+                uri.request_uri,
+                "User-Agent" => "Choria Playbooks http://choria.io",
+                "X-Header" => "x_value",
+                "Content-Type" => "application/json"
+              ).returns(post)
+              post.expects(:body=).with({"rspec1" => 1, "rspec2" => 2}.to_json)
+
+              expect(task.http_post_request(uri)).to be(post)
+            end
+          end
+
+          describe "#http_get_request" do
+            it "should create the right request" do
+              uri = task.create_uri
+              get = stub(:https)
+
+              Net::HTTP::Get.expects(:new).with(uri.request_uri, "User-Agent" => "Choria Playbooks http://choria.io", "X-Header" => "x_value").returns(get)
+
+              expect(task.http_get_request(uri)).to be(get)
+            end
+          end
+
+          describe "#create_uri" do
+            it "should support GET method" do
+              task.instance_variable_set("@method", "GET")
+              expect(task.create_uri.to_s).to eq("http://localhost/rspec?foo=bar&rspec1=1&rspec2=2")
+            end
+
+            it "should support other methods" do
+              expect(task.create_uri.to_s).to eq("http://localhost/rspec?foo=bar")
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows for sending arbitrary GET and POSTs to URIs

    - webhook:
        uri: https://localhost/webhook
        method: POST
        headers:
          "X-Foo-Header": "ho ho ho"
        data:
          "test": "testing testing testing"