### PR TITLE
(#118) Add date, utc_date and uuid support to templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2016/12/29|118   |Support UUID and time stamps in templates                                                                |
 |2016/12/29|      |Release 0.0.13                                                                                           |
 |2016/12/28|113   |Add a terraform node set                                                                                 |
 |2016/12/28|96    |Add a webhook task used to GET and POST to other systems                                                 |


### PR DESCRIPTION
Allows for:

    {{{ uuid }}} to get a M::SSL.uuid generated UUID
    {{{ date(%FT%T) }}} for a local time time stamp in the given format
    {{{ utc_date(%FT%T) }}} for same in UTC

Closes #118 