### PR TITLE
(#117) Do not merge multiple SRV records into one

### DIFF
--- a/spec/unit/mcollective/util/choria_spec.rb
+++ b/spec/unit/mcollective/util/choria_spec.rb
@@ -64,12 +64,13 @@ module MCollective
 
       describe "#try_srv" do
         it "should query for the correct names" do
-          choria.expects(:query_srv_records).with(["rspec1", "rspec2"]).returns([:target => "rspec.host", :port => "8080"])
-          expect(choria.try_srv(["rspec1", "rspec2"], "h", "1")).to eq(:target => "rspec.host", :port => "8080")
+          choria.expects(:query_srv_records).with(["rspec1"]).returns([:target => "rspec.host1", :port => "8081"])
+          choria.expects(:query_srv_records).with(["rspec2"]).returns([:target => "rspec.host2", :port => "8082"])
+          expect(choria.try_srv(["rspec1", "rspec2"], "h", "1")).to eq(:target => "rspec.host1", :port => "8081")
         end
 
         it "should support defaults" do
-          choria.expects(:query_srv_records).with(["rspec1", "rspec2"]).returns([])
+          choria.expects(:query_srv_records).returns([]).twice
           expect(choria.try_srv(["rspec1", "rspec2"], "rspec.host", "8080")).to eq(:target => "rspec.host", :port => "8080")
         end
       end


### PR DESCRIPTION
When attempting to find the PuppetDB node we have to fist try
PuppetDB SRV record and then the Puppet one and after that resort
to configured defaults.  First one wins.

Before this it queried all the given SRV records - both PuppetDB and
Puppet ones - and then merged the answers and sorted by SRV conventions
so you ended up with luck of the draw hitting either PuppetDB or Puppet
should both sets of SRV records exist.

Now it will prioritise the PuppetDB ones