### PR TITLE
(#106) Update the NATS client gem to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2016/12/31|106   |Update the NATS gem to 0.2.0                                                                             |
+|2016/12/29|117   |When both a PuppetDB SRV record and a Puppet one existed results were randomly chosen hosts              |
 |2016/12/29|118   |Support UUID and time stamps in templates                                                                |
 |2016/12/29|      |Release 0.0.13                                                                                           |
 |2016/12/28|113   |Add a terraform node set                                                                                 |

--- a/lib/mcollective/application/playbook.rb
+++ b/lib/mcollective/application/playbook.rb
@@ -8,7 +8,7 @@ module MCollective
 
   The ACTION can be one of the following:
 
-    show      - preview the playbook
+    show      - preview the playbook in parsed YAML format
     run       - run the playbook as your local user
 
   The PLAYBOOK is a YAML file describing the tasks
@@ -104,7 +104,7 @@ module MCollective
       def show_command
         disconnect
 
-        pp YAML.load_file(configuration[:__playbook_file])
+        puts YAML.dump(YAML.load_file(configuration[:__playbook_file]))
       end
 
       def main

--- a/module/data/plugin.yaml
+++ b/module/data/plugin.yaml
@@ -1,7 +1,7 @@
 ---
 mcollective_choria::config_name: choria
 mcollective_choria::gem_dependencies:
-  "nats-pure": "0.1.2"
+  "nats-pure": "0.2.0"
 
 mcollective_choria::client_directories:
  - util/playbook
@@ -14,9 +14,9 @@ mcollective_choria::client_files:
  - util/playbook/playbook_logger.rb
  - util/playbook/tasks
  - util/playbook/tasks/mcollective_task.rb
+ - util/playbook/tasks/mcollective_assert_task.rb
  - util/playbook/tasks/shell_task.rb
  - util/playbook/tasks/slack_task.rb
- - util/playbook/tasks/mcollective_assert_task.rb
  - util/playbook/tasks/webhook_task.rb
  - util/playbook/tasks.rb
  - util/playbook/nodes.rb


### PR DESCRIPTION
Improved error messaging and configurable timeouts which we dont expose
as configurable to the user at this point

Closes #106 