### PR TITLE
(#125) adjust dependencies for librarian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/01/03|125   |Adjust dependencies so these modules work with librarian                                                 |
 |2016/12/31|      |Release 0.0.14                                                                                           |
 |2016/12/31|106   |Update the NATS gem to 0.2.0                                                                             |
 |2016/12/29|117   |When both a PuppetDB SRV record and a Puppet one existed results were randomly chosen hosts              |

--- a/module/metadata.json
+++ b/module/metadata.json
@@ -8,7 +8,13 @@
   "project_page": "https://github.com/ripienaar/mcollective-choria/wiki",
   "issues_url": "https://github.com/ripienaar/mcollective-choria/issues",
   "dependencies": [
-    {"name":"ripienaar/mcollective","version_requirement":">= 0.0.19 < 2.0.0"}
+    {"name":"ripienaar/mcollective","version_requirement":">= 0.0.21 < 2.0.0"},
+    { "name": "ripienaar/mcollective_agent_puppet", "version_requirement": ">= 1.11.0" },
+    { "name": "ripienaar/mcollective_agent_package", "version_requirement": ">= 4.3.0" },
+    { "name": "ripienaar/mcollective_agent_service", "version_requirement": ">= 3.1.3" },
+    { "name": "ripienaar/mcollective_agent_filemgr", "version_requirement": ">= 1.1.0" },
+    { "name": "ripienaar/mcollective_util_actionpolicy", "version_requirement": ">= 2.1.0" }
+    { "name": "ripienaar/nats", "version_requirement": ">= 0.0.5" }
   ],
   "data_provider": "hiera"
 }


### PR DESCRIPTION
The mcollective module pulled choria and other related modules in as
dependencies while these in turn depend on the mcollective one.

This ciruclar dependency was working for puppet module but not for
librarian, this corrects things so the mcollective module is for
managing mcollective and the choria one brings in all its needs which is
more correct

Also add the nats module as a dependency, choria users now just need to
install this one module