### PR TITLE
(#127) allow SRV record support to be disabled globally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
-|2016/01/03|      |Release 0.0.15                                                                                           |
+|2017/01/04|127   |Allow SRV record support to be disabled                                                                  |
+|2017/01/03|      |Release 0.0.15                                                                                           |
 |2017/01/03|125   |Adjust dependencies so these modules work with librarian                                                 |
 |2016/12/31|      |Release 0.0.14                                                                                           |
 |2016/12/31|106   |Update the NATS gem to 0.2.0                                                                             |

--- a/lib/mcollective/util/choria.rb
+++ b/lib/mcollective/util/choria.rb
@@ -73,12 +73,19 @@ module MCollective
 
       # Query DNS for a series of records
       #
-      # The given records will be passed through {#srv_records} to figure out the domain to query in
+      # The given records will be passed through {#srv_records} to figure out the domain to query in.
+      #
+      # Querying of records can be bypassed by setting choria.use_srv_records to false
       #
       # @yield [Hash] each record for modification by the caller
       # @param records [Array<String>] the records to query without their domain parts
       # @return [Array<Hash>] with keys :port, :priority, :weight and :target
       def query_srv_records(records)
+        unless ["t", "true", "yes", "1"].include?(get_option("choria.use_srv_records", "1").downcase)
+          Log.info("Skipping SRV record queries due to choria.query_srv_records setting")
+          return []
+        end
+
         answers = Array(srv_records(records)).map do |record|
           answers = resolver.getresources(record, Resolv::DNS::Resource::IN::SRV)
           Log.debug("Found %d SRV records for %s" % [answers.size, record])

--- a/spec/unit/mcollective/util/choria_spec.rb
+++ b/spec/unit/mcollective/util/choria_spec.rb
@@ -149,6 +149,12 @@ module MCollective
 
           expect(choria.query_srv_records(["_mcollective-server._tcp", "_x-puppet-mcollective._tcp"])).to eq([result1, result2])
         end
+
+        it "should be possible to disable SRV support" do
+          Config.instance.stubs(:pluginconf).returns("choria.use_srv_records" => "false")
+          choria.expects(:srv_records).never
+          expect(choria.query_srv_records(["_mcollective-server._tcp.example.net"])).to eq([])
+        end
       end
 
       describe "#facter_cmd" do


### PR DESCRIPTION
Previously SRV records were always on, but this is problematic where
development environments happen to share the same domain as production
servers.

Only real option was to set a srv domain of some other domain just to
avoid hooking dev up to prod NATS, Puppet etc, clearly thats a problem

Now one can disable SRV by setting choria.use_srv_records to anything
other than t, true, yes, 1