### PR TITLE
(#122) Add a JSON based audit log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/01/07|129   |Add a choria audit plugin that logs in JSON format                                                       |
 |2017/01/04|127   |Allow SRV record support to be disabled                                                                  |
 |2017/01/03|      |Release 0.0.15                                                                                           |
 |2017/01/03|125   |Adjust dependencies so these modules work with librarian                                                 |

--- a/lib/mcollective/audit/choria.rb
+++ b/lib/mcollective/audit/choria.rb
@@ -1,0 +1,34 @@
+module MCollective
+  module Audit
+    class Choria < RPC::Audit
+      def audit_request(request, connection)
+        logfile = Config.instance.pluginconf["rpcaudit.logfile"]
+
+        unless logfile
+          Log.warn("Auditing is not functional because rpcaudit.logfile is not set")
+          return
+        end
+
+        unless File.writable?(logfile)
+          Log.warn("Auditing is not functional because logfile '%s' is not writable" % logfile)
+          return
+        end
+
+        message = {
+          "timestamp" => Time.now.utc.strftime("%Y-%m-%dT%H:%M:%S.%6N%z"),
+          "request_id" => request.uniqid,
+          "request_time" => request.time,
+          "caller" => request.caller,
+          "sender" => request.sender,
+          "agent" => request.agent,
+          "action" => request.action,
+          "data" => request.data
+        }
+
+        File.open(logfile, "a") do |f|
+          f.puts(message.to_json)
+        end
+      end
+    end
+  end
+end

--- a/module/README.md
+++ b/module/README.md
@@ -29,10 +29,7 @@ See [choria.io](http://choria.io) for full details
 
 ## Usage
 
-This module is automatically set up for you when you use the [ripienaar-mcollective](https://forge.puppet.com/ripienaar/mcollective)
-module.
-
-A deployment guide can be found at the [wiki](https://github.com/ripienaar/mcollective-choria/wiki)
+A deployment guide can be found at the [Choria Website](http://choria.io)
 
 ## Data Reference
 

--- a/module/data/plugin.yaml
+++ b/module/data/plugin.yaml
@@ -5,6 +5,8 @@ mcollective_choria::gem_dependencies:
 
 mcollective_choria::client_directories:
  - util/playbook
+mcollective_choria::server_files:
+ - audit/choria.rb
 mcollective_choria::client_files:
  - discovery/choria.ddl
  - discovery/choria.rb
@@ -30,7 +32,7 @@ mcollective_choria::client_files:
  - util/playbook/nodes/terraform_nodes.rb
  - util/playbook/inputs.rb
 mcollective_choria::common_directories:
-  - util/choria
+ - util/choria
 mcollective_choria::common_files:
  - security/choria.rb
  - connector/nats.ddl

--- a/spec/unit/mcollective/audit/choria_spec.rb
+++ b/spec/unit/mcollective/audit/choria_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+require "mcollective/audit/choria"
+
+module MCollective
+  module Audit
+    describe Choria do
+      let(:choria) { Choria.new }
+
+      describe(:audit_request) do
+        it "should warn about rpcaudit.logfile" do
+          Config.instance.stubs(:pluginconf).returns({})
+          Log.expects(:warn).with("Auditing is not functional because rpcaudit.logfile is not set")
+          File.expects(:writable?).never
+
+          choria.audit_request(stub, stub)
+        end
+
+        it "should warn when it cant write" do
+          Config.instance.stubs(:pluginconf).returns("rpcaudit.logfile" => "/nonexisting/audit.log")
+          File.expects(:writable?).with("/nonexisting/audit.log").returns(false)
+          Log.expects(:warn).with("Auditing is not functional because logfile '/nonexisting/audit.log' is not writable")
+
+          choria.audit_request(stub, stub)
+        end
+
+        it "should log the correct data" do
+          msg = {
+            :msgtime => 1483774088,
+            :senderid => "rspec.example.net",
+            :requestid => "rspec.req.id",
+            :callerid => "choria=rspec",
+            :body => {
+              :agent => "rspec_agent",
+              :action => "rspec_action",
+              :data => {:rspec => :data}
+            }
+          }
+
+          Config.instance.stubs(:pluginconf).returns("rpcaudit.logfile" => "/nonexisting/audit.log")
+          File.expects(:writable?).with("/nonexisting/audit.log").returns(true)
+          File.expects(:open).with("/nonexisting/audit.log", "a").yields(file = StringIO.new)
+          Time.expects(:now).returns(Time.at(1483774088))
+
+          choria.audit_request(RPC::Request.new(msg, stub), stub)
+
+          expected = {
+            "timestamp" => "2017-01-07T07:28:08.000000+0000",
+            "request_id" => "rspec.req.id",
+            "request_time" => 1483774088,
+            "caller" => "choria=rspec",
+            "sender" => "rspec.example.net",
+            "agent" => "rspec_agent",
+            "action" => "rspec_action",
+            "data" => {
+              :rspec => :data
+            }
+          }.to_json
+
+          expect(file.string.chomp).to eq(expected)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The old audit log predates things like elasticsearch and such, this now
produces a JSON based audit log that should be more friendly to modern
tooling including jq

Closes #122 