### PR TITLE
(#101) Expose the last task status to the templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/01/11|101   |Expose previous task status via templates                                                                |
 |2017/01/07|129   |Add a choria audit plugin that logs in JSON format                                                       |
 |2017/01/04|127   |Allow SRV record support to be disabled                                                                  |
 |2017/01/03|      |Release 0.0.15                                                                                           |

--- a/lib/mcollective/util/playbook.rb
+++ b/lib/mcollective/util/playbook.rb
@@ -193,6 +193,44 @@ module MCollective
         @inputs[input]
       end
 
+      # Looks up a proeprty of the previous task
+      #
+      # @param property [success, msg, message, data, description]
+      # @return [Object]
+      def previous_task(property)
+        if property == "success"
+          return false unless previous_task_result && previous_task_result.ran
+
+          previous_task_result.success
+        elsif ["msg", "message"].include?(property)
+          return "No previous task were found" unless previous_task_result
+          return "Previous task did not run" unless previous_task_result.ran
+
+          previous_task_result.msg
+        elsif property == "data"
+          return [] unless previous_task_result && previous_task_result.ran
+
+          previous_task_result.data || []
+        elsif property == "description"
+          return "No previous task were found" unless previous_task_result
+
+          previous_task_result.task[:description]
+        elsif property == "runtime"
+          return 0 unless previous_task_result && previous_task_result.ran
+
+          previous_task_result.run_time.round(2)
+        else
+          raise("Cannot retrieve %s for the last task outcome" % property)
+        end
+      end
+
+      # Find the last result from the tasks ran
+      #
+      # @return [TaskResult,nil]
+      def previous_task_result
+        @tasks.results.last
+      end
+
       # Adds the CLI options for an application based on the playbook inputs
       #
       # @see Inputs#add_cli_options

--- a/lib/mcollective/util/playbook/task_result.rb
+++ b/lib/mcollective/util/playbook/task_result.rb
@@ -1,0 +1,50 @@
+module MCollective
+  module Util
+    class Playbook
+      class TaskResult
+        attr_accessor :success, :msg, :data, :ran, :task
+
+        def initialize
+          @start_time = Time.now
+          @end_time = @start_time
+          @ran = false
+          @task = nil
+        end
+
+        def run_time
+          @end_time - @start_time
+        end
+
+        def success?
+          !!success
+        end
+
+        def timed_run(task)
+          @start_time = Time.now
+          @task = task
+
+          begin
+            @success, @msg, @data = task[:runner].run
+
+            if !@success && task[:properties]["fail_ok"]
+              Log.warn("Task failed but fail_ok is true, treating as success")
+              @success = true
+            end
+          rescue
+            @success = false
+            @data = [$!]
+            @msg = "Running task %s failed unexpectedly: %s: %s" % [task.to_s, $!.class, $!.to_s]
+
+            Log.warn(@msg)
+            Log.debug($!.backtrace.join("\n\t"))
+          end
+
+          @end_time = Time.now
+          @ran = true
+
+          self
+        end
+      end
+    end
+  end
+end

--- a/lib/mcollective/util/playbook/tasks/base.rb
+++ b/lib/mcollective/util/playbook/tasks/base.rb
@@ -1,0 +1,33 @@
+module MCollective
+  module Util
+    class Playbook
+      class Tasks
+        class Base
+          attr_accessor :description
+
+          def to_s
+            "#<%s description: %s>" % [self.class, description]
+          end
+
+          def run_task(result)
+            validate_configuration!
+
+            result.timed_run(self)
+          end
+
+          def run
+            raise(NotImplementedError, "run not implemented", caller)
+          end
+
+          def validate_configuration!
+            raise(NotImplementedError, "validate_configuration! not implemented", caller)
+          end
+
+          def from_hash(properties)
+            raise(NotImplementedError, "from_hash not implemented", caller)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mcollective/util/playbook/tasks/mcollective_assert_task.rb
+++ b/lib/mcollective/util/playbook/tasks/mcollective_assert_task.rb
@@ -2,7 +2,7 @@ module MCollective
   module Util
     class Playbook
       class Tasks
-        class Mcollective_assertTask
+        class Mcollective_assertTask < Base
           def initialize
             @properties = {}
             @nodes = []
@@ -10,7 +10,6 @@ module MCollective
             @pre_sleep = 10
             @expression = []
             @pre_slept = false
-            @description = nil
           end
 
           def from_hash(data)

--- a/lib/mcollective/util/playbook/tasks/mcollective_task.rb
+++ b/lib/mcollective/util/playbook/tasks/mcollective_task.rb
@@ -2,7 +2,7 @@ module MCollective
   module Util
     class Playbook
       class Tasks
-        class McollectiveTask
+        class McollectiveTask < Base
           def initialize
             @properties = {}
             @post = []
@@ -60,7 +60,6 @@ module MCollective
             @batch_size = data["batch_size"]
             @properties = data.fetch("properties", {})
             @post = data.fetch("post", [])
-            @description = data["description"]
             @log_replies = !data.fetch("silent", false)
 
             @_rpc_client = nil

--- a/lib/mcollective/util/playbook/tasks/shell_task.rb
+++ b/lib/mcollective/util/playbook/tasks/shell_task.rb
@@ -2,11 +2,10 @@ module MCollective
   module Util
     class Playbook
       class Tasks
-        class ShellTask
+        class ShellTask < Base
           def validate_configuration!
             raise("A command was not given") unless @command
             raise("Nodes were given but is not an array") if @nodes && !@nodes.is_a?(Array)
-            raise("Nodes can not be empty") if @nodes.empty?
           end
 
           def from_hash(data)

--- a/lib/mcollective/util/playbook/tasks/slack_task.rb
+++ b/lib/mcollective/util/playbook/tasks/slack_task.rb
@@ -5,7 +5,7 @@ module MCollective
   module Util
     class Playbook
       class Tasks
-        class SlackTask
+        class SlackTask < Base
           def validate_configuration!
             raise("A channel is required") unless @channel
             raise("Message text is required") unless @text

--- a/lib/mcollective/util/playbook/tasks/webhook_task.rb
+++ b/lib/mcollective/util/playbook/tasks/webhook_task.rb
@@ -5,7 +5,7 @@ module MCollective
   module Util
     class Playbook
       class Tasks
-        class WebhookTask
+        class WebhookTask < Base
           USER_AGENT = "Choria Playbooks http://choria.io".freeze
 
           def validate_configuration!

--- a/lib/mcollective/util/playbook/template_util.rb
+++ b/lib/mcollective/util/playbook/template_util.rb
@@ -42,6 +42,8 @@ module MCollective
             @playbook.discovered_nodes(item)
           when "metadata"
             @playbook.metadata_item(item)
+          when "previous_task"
+            @playbook.previous_task(item)
           when "date"
             Time.now.strftime(item)
           when "utc_date"
@@ -61,14 +63,17 @@ module MCollective
 
           data_regex = Regexp.new("%s%s%s" % [front, '(?<type>input(s*)|metadata|nodes)\.(?<item>[a-zA-Z0-9\_\-]+)', back])
           date_regex = Regexp.new("%s%s%s" % [front, '(?<type>date|utc_date)\(\s*["\']*(?<format>.+?)["\']*\s*\)', back])
+          task_regex = Regexp.new("%s%s%s" % [front, '(?<type>previous_task)\.(?<item>(success|description|msg|message|data|runtime))', back])
           uuid_regex = Regexp.new("%s%s%s" % [front, "uuid", back])
 
-          combined_regex = Regexp.union(data_regex, date_regex, uuid_regex)
+          combined_regex = Regexp.union(data_regex, date_regex, task_regex, uuid_regex)
 
           if req = string.match(/^#{data_regex}$/)
             __template_resolve(req["type"], req["item"])
           elsif req = string.match(/^#{date_regex}$/)
             __template_resolve(req["type"], req["format"])
+          elsif req = string.match(/^#{task_regex}$/)
+            __template_resolve(req["type"], req["item"])
           elsif string =~ /^#{uuid_regex}$/
             __template_resolve("uuid", "")
           else

--- a/spec/unit/mcollective/util/playbook/task_result_spec.rb
+++ b/spec/unit/mcollective/util/playbook/task_result_spec.rb
@@ -1,0 +1,69 @@
+require "spec_helper"
+require "mcollective/util/playbook"
+
+module MCollective
+  module Util
+    class Playbook
+      describe TaskResult do
+        let(:tr) { TaskResult.new }
+
+        describe "#run_time" do
+          it "should calculate the right elapsed time" do
+            expect(tr.run_time).to eq(0)
+
+            tr.instance_variable_set("@end_time", Time.now + 10)
+            expect(tr.run_time).to be_within(0.1).of(10)
+          end
+        end
+
+        describe "#timed_run" do
+          it "should run and update properties" do
+            runner = stub(:run => [true, "rspec", [:rspec]])
+            task = {:runner => runner}
+
+            expect(tr.ran).to be(false)
+
+            tr.timed_run(task)
+
+            expect(tr.task).to be(task)
+            expect(tr.msg).to eq("rspec")
+            expect(tr.data).to eq([:rspec])
+            expect(tr.success).to be(true)
+            expect(tr.ran).to be(true)
+          end
+
+          it "should support fail_ok" do
+            runner = stub(:run => [false, "rspec", [:rspec]])
+            task = {:runner => runner, :properties => {"fail_ok" => true}}
+            tr.timed_run(task)
+
+            expect(tr.task).to be(task)
+            expect(tr.msg).to eq("rspec")
+            expect(tr.data).to eq([:rspec])
+            expect(tr.success).to be(true)
+          end
+
+          it "should handle exceptions" do
+            runner = stub
+            runner.stubs(:run).raises("rspec")
+            task = {:runner => runner}
+            tr.timed_run(task)
+
+            expect(tr.task).to be(task)
+            expect(tr.msg).to match(/Running task .+ failed unexpectedly: RuntimeError: rspec/)
+            expect(tr.data.first).to be_a(RuntimeError)
+            expect(tr.success).to be(false)
+          end
+        end
+
+        describe "#success?" do
+          it "should correctly report success" do
+            expect(tr.success?).to be(false)
+            tr.success = true
+            expect(tr.success?).to be(true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/mcollective/util/playbook/tasks/mcollective_task_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks/mcollective_task_spec.rb
@@ -150,7 +150,6 @@ module MCollective
               expect(task.instance_variable_get("@agent")).to eq("puppet")
               expect(task.instance_variable_get("@action")).to eq("disable")
               expect(task.instance_variable_get("@batch_size")).to eq(10)
-              expect(task.instance_variable_get("@description")).to eq("disable puppet")
               expect(task.instance_variable_get("@post")).to eq(["summarize"])
               expect(task.instance_variable_get("@log_replies")).to eq(true)
               expect(task.instance_variable_get("@properties")).to eq(:message => "rspec")

--- a/spec/unit/mcollective/util/playbook/tasks/shell_task_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks/shell_task_spec.rb
@@ -64,12 +64,6 @@ module MCollective
                 "nodes" => 1
               )
               expect { task.validate_configuration! }.to raise_error("Nodes were given but is not an array")
-
-              task.from_hash(
-                "command" => "/tmp/x.sh",
-                "nodes" => []
-              )
-              expect { task.validate_configuration! }.to raise_error("Nodes can not be empty")
             end
           end
 

--- a/spec/unit/mcollective/util/playbook/template_util_spec.rb
+++ b/spec/unit/mcollective/util/playbook/template_util_spec.rb
@@ -19,16 +19,18 @@ module MCollective
             expect { tu.__template_process_string("") }.to raise_error("Playbook is not accessible")
           end
 
-          it "should lookup inputs, metadata and nodes and preserve data type" do
+          it "should lookup inputs, metadata and nodes, previous_task and preserve data type" do
             tu.expects(:__template_resolve).with("input", "x").returns(1)
             tu.expects(:__template_resolve).with("inputs", "y").returns(1)
             tu.expects(:__template_resolve).with("nodes", "x").returns(["value1", "value2"])
             tu.expects(:__template_resolve).with("metadata", "x").returns(2)
+            tu.expects(:__template_resolve).with("previous_task", "msg").returns("rspec_message")
 
             expect(tu.__template_process_string("{{{ input.x }}}")).to eq(1)
             expect(tu.__template_process_string("{{{ inputs.y }}}")).to eq(1)
             expect(tu.__template_process_string("{{{ nodes.x}}}")).to eq(["value1", "value2"])
             expect(tu.__template_process_string("{{{metadata.x}}}")).to eq(2)
+            expect(tu.__template_process_string("{{{previous_task.msg}}}")).to eq("rspec_message")
           end
 
           it "should support dates" do
@@ -55,6 +57,11 @@ module MCollective
         end
 
         describe "#__template_resolve" do
+          it "should support previous_task" do
+            playbook.expects(:previous_task).with("rspec").returns("value")
+            expect(tu.__template_resolve("previous_task", "rspec")).to eq("value")
+          end
+
           it "should support inputs" do
             playbook.expects(:input_value).with("rspec").returns("value").twice
             expect(tu.__template_resolve("input", "rspec")).to eq("value")

--- a/spec/unit/mcollective/util/tasks/mcollective_task_spec.rb
+++ b/spec/unit/mcollective/util/tasks/mcollective_task_spec.rb
@@ -150,7 +150,6 @@ module MCollective
               expect(task.instance_variable_get("@agent")).to eq("puppet")
               expect(task.instance_variable_get("@action")).to eq("disable")
               expect(task.instance_variable_get("@batch_size")).to eq(10)
-              expect(task.instance_variable_get("@description")).to eq("disable puppet")
               expect(task.instance_variable_get("@post")).to eq(["summarize"])
               expect(task.instance_variable_get("@log_replies")).to eq(true)
               expect(task.instance_variable_get("@properties")).to eq(:message => "rspec")


### PR DESCRIPTION
This adds a basic status object for task results that gets associated
with every task.  It stores the success, msg, data, description and run
time of every task.  This object is quite basic now and will no doubt
extend a bit when we get to reports.

This will eventually be added to reports and such but for now to get us
going it's used to expose the last task status via templates as
previous_task.success or .msg etc

New template items:

  previous_task.success
  previous_task.description
  previous_task.msg or previous_task.message
  previous_task.data
  previous_task.runtime

Closes #101 