### PR TITLE
(#88) Add reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/01/12|88    |Add playbook reports                                                                                     |
 |2017/01/11|101   |Expose previous task status via templates                                                                |
 |2017/01/07|129   |Add a choria audit plugin that logs in JSON format                                                       |
 |2017/01/04|127   |Allow SRV record support to be disabled                                                                  |

--- a/lib/mcollective/util/playbook/playbook_logger.rb
+++ b/lib/mcollective/util/playbook/playbook_logger.rb
@@ -6,6 +6,7 @@ module MCollective
       class Playbook_Logger < Logger::Console_logger
         def initialize(playbook)
           @playbook = playbook
+          @report = playbook.report
 
           super()
         end
@@ -17,16 +18,19 @@ module MCollective
         def log(level, from, msg, normal_output=STDERR, last_resort_output=STDERR)
           if @playbook.loglevel != "debug"
             if should_show?
-              from = "%s#%-25s" % [@playbook.name, @playbook.context]
+              console_from = "%s#%-25s" % [@playbook.name, @playbook.context]
             else
               level = :debug
             end
           end
 
           if @known_levels.index(level) >= @known_levels.index(@active_level)
-            time = Time.new.strftime("%H:%M:%S")
+            r_time = Time.now
+            s_time = r_time.strftime("%H:%M:%S")
 
-            normal_output.puts("%s %s: %s %s" % [colorize(level, level[0].capitalize), time, from, msg])
+            @report.append_log(r_time, level, from, msg)
+
+            normal_output.puts("%s %s: %s %s" % [colorize(level, level[0].capitalize), s_time, console_from, msg])
           end
         rescue
           last_resort_output.puts("%s: %s" % [level, msg])

--- a/lib/mcollective/util/playbook/report.rb
+++ b/lib/mcollective/util/playbook/report.rb
@@ -1,0 +1,132 @@
+module MCollective
+  module Util
+    class Playbook
+      class Report
+        def initialize(playbook)
+          @playbook = playbook
+          @logs = []
+          @timestamp = Time.now.utc
+          @version = 1
+          @nodes = {}
+          @tasks = []
+          @success = false
+
+          @metrics = {
+            "start_time" => @timestamp,
+            "end_time" => @timestamp,
+            "run_time" => 0,
+            "task_count" => 0,
+            "task_types" => {}
+          }
+
+          @inputs = {
+            "static" => {},
+            "dynamic" => []
+          }
+        end
+
+        def finalize(success, fail_msg=nil)
+          @success = success
+          @fail_message = fail_msg
+
+          store_playbook_metadata
+          store_static_inputs
+          store_node_groups
+          store_task_results
+          calculate_metrics
+
+          to_report
+        end
+
+        def to_report
+          {
+            "report" => {
+              "version" => @version,
+              "timestamp" => @timestamp,
+              "success" => @success,
+              "playbook_error" => @fail_message
+            },
+
+            "playbook" => {
+              "name" => @playbook_name,
+              "version" => @playbook_version
+            },
+
+            "inputs" => @inputs,
+            "nodes" => @nodes,
+            "tasks" => @tasks,
+            "metrics" => @metrics,
+            "logs" => @logs
+          }
+        end
+
+        def calculate_metrics
+          @metrics["end_time"] = Time.now.utc
+          @metrics["run_time"] = @metrics["end_time"] - @metrics["start_time"]
+          @metrics["task_count"] = @tasks.size
+
+          @tasks.each do |task|
+            @metrics["task_types"][task["type"]] ||= {
+              "count" => 0,
+              "total_time" => 0,
+              "pass" => 0,
+              "fail" => 0
+            }
+
+            metrics = @metrics["task_types"][task["type"]]
+
+            metrics["count"] += 1
+            metrics["total_time"] += task["run_time"]
+            task["success"] ? metrics["pass"] += 1 : metrics["fail"] += 1
+          end
+
+          @metrics
+        end
+
+        def store_task_results
+          @playbook.task_results.each do |result|
+            @tasks << {
+              "type" => result.task_type,
+              "set" => result.set,
+              "description" => result.description,
+              "start_time" => result.start_time.utc,
+              "end_time" => result.end_time.utc,
+              "run_time" => result.run_time,
+              "ran" => result.ran,
+              "msg" => result.msg,
+              "success" => result.success
+            }
+          end
+
+          @tasks
+        end
+
+        def store_playbook_metadata
+          @playbook_name = @playbook.name
+          @playbook_version = @playbook.version
+        end
+
+        def store_node_groups
+          @playbook.nodes.each do |key|
+            @nodes[key] = @playbook.discovered_nodes(key)
+          end
+        end
+
+        def store_static_inputs
+          @playbook.inputs.each do |key|
+            @inputs["static"][key] = @playbook.input_value(key)
+          end
+        end
+
+        def append_log(time, level, from, msg)
+          @logs << {
+            "time" => time.utc.to_i,
+            "level" => level.to_s,
+            "from" => from.strip,
+            "msg" => msg
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/mcollective/util/playbook/task_result.rb
+++ b/lib/mcollective/util/playbook/task_result.rb
@@ -2,13 +2,14 @@ module MCollective
   module Util
     class Playbook
       class TaskResult
-        attr_accessor :success, :msg, :data, :ran, :task
+        attr_accessor :success, :msg, :data, :ran, :task, :set
 
         def initialize
           @start_time = Time.now
           @end_time = @start_time
           @ran = false
           @task = nil
+          @set = nil
         end
 
         def run_time
@@ -19,9 +20,10 @@ module MCollective
           !!success
         end
 
-        def timed_run(task)
+        def timed_run(task, set)
           @start_time = Time.now
           @task = task
+          @set = set
 
           begin
             @success, @msg, @data = task[:runner].run

--- a/lib/mcollective/util/playbook/task_result.rb
+++ b/lib/mcollective/util/playbook/task_result.rb
@@ -3,13 +3,18 @@ module MCollective
     class Playbook
       class TaskResult
         attr_accessor :success, :msg, :data, :ran, :task, :set
+        attr_accessor :start_time, :end_time, :description
 
-        def initialize
+        def initialize(task)
           @start_time = Time.now
           @end_time = @start_time
           @ran = false
-          @task = nil
-          @set = nil
+          @task = task
+          @description = task[:description]
+        end
+
+        def task_type
+          @task[:type]
         end
 
         def run_time
@@ -20,9 +25,8 @@ module MCollective
           !!success
         end
 
-        def timed_run(task, set)
+        def timed_run(set)
           @start_time = Time.now
-          @task = task
           @set = set
 
           begin

--- a/lib/mcollective/util/playbook/tasks.rb
+++ b/lib/mcollective/util/playbook/tasks.rb
@@ -47,9 +47,10 @@ module MCollective
         # Runs a specific task
         #
         # @param task [Hash] a task entry
+        # @param set [String] the set the task is running in
         # @param hooks [Boolean] indicates if hooks should be run
         # @return [Boolean] indicating task success
-        def run_task(task, hooks=true)
+        def run_task(task, set, hooks=true)
           properties = task[:properties]
           result = task[:result]
           task_runner = task[:runner]
@@ -65,7 +66,7 @@ module MCollective
             task_runner.from_hash(t(properties))
             task_runner.validate_configuration!
 
-            @results << result.timed_run(task)
+            @results << result.timed_run(task, set)
 
             Log.info(result.msg)
 
@@ -100,7 +101,7 @@ module MCollective
             # would typically use map here but you cant break out of a map and keep the thus far built up array
             # so it's either this or a inject loop
             passed = set_tasks.take_while do |task|
-              @playbook.in_context("%s.%s" % [set, task[:type]]) { run_task(task, set == "tasks") }
+              @playbook.in_context("%s.%s" % [set, task[:type]]) { run_task(task, set, set == "tasks") }
             end
 
             set_success = passed.size == set_tasks.size

--- a/lib/mcollective/util/playbook/tasks.rb
+++ b/lib/mcollective/util/playbook/tasks.rb
@@ -66,7 +66,7 @@ module MCollective
             task_runner.from_hash(t(properties))
             task_runner.validate_configuration!
 
-            @results << result.timed_run(task, set)
+            @results << result.timed_run(set)
 
             Log.info(result.msg)
 
@@ -146,8 +146,7 @@ module MCollective
               runner = runner_for(type)
               runner.description = props.fetch("description", "%s task" % [type])
 
-              @tasks[set] << {
-                :result => TaskResult.new,
+              task_data = {
                 :description => runner.description,
                 :type => type,
                 :runner => runner,
@@ -157,6 +156,10 @@ module MCollective
                   "fail_ok" => false
                 }.merge(props)
               }
+
+              task_data[:result] = TaskResult.new(task_data)
+
+              @tasks[set] << task_data
             end
           end
         end

--- a/spec/unit/mcollective/util/playbook/report_spec.rb
+++ b/spec/unit/mcollective/util/playbook/report_spec.rb
@@ -1,0 +1,172 @@
+require "spec_helper"
+require "mcollective/util/playbook"
+
+module MCollective
+  module Util
+    class Playbook
+      describe Report do
+        let(:playbook) { Playbook.new }
+        let(:nodes) { playbook.instance_variable_get("@nodes") }
+        let(:tasks) { playbook.instance_variable_get("@tasks") }
+        let(:uses) { playbook.instance_variable_get("@uses") }
+        let(:inputs) { playbook.instance_variable_get("@inputs") }
+        let(:report) { playbook.report }
+        let(:playbook_fixture) { YAML.load(File.read("spec/fixtures/playbooks/playbook.yaml")) }
+        let(:results) do
+          [
+            stub(
+              :task_type => "rspec_type1",
+              :set => "rspec_set1",
+              :description => "rspec test1",
+              :start_time => Time.at(1484245208),
+              :end_time => Time.at(1484245209),
+              :run_time => 1.0,
+              :ran => true,
+              :msg => "rspec message",
+              :success => true
+            ),
+            stub(
+              :task_type => "rspec_type2",
+              :set => "rspec_set2",
+              :description => "rspec test2",
+              :start_time => Time.at(1484245210),
+              :end_time => Time.at(1484245212),
+              :run_time => 2.0,
+              :ran => true,
+              :msg => "rspec message",
+              :success => false
+            )
+          ]
+        end
+
+        before(:each) do
+          playbook.from_hash(playbook_fixture)
+          playbook.stubs(:task_results).returns(results)
+        end
+
+        describe "#finalize" do
+          it "should fetch all data and produce a report" do
+            report.expects(:store_playbook_metadata)
+            report.expects(:store_static_inputs)
+            report.expects(:store_node_groups)
+            report.expects(:store_task_results)
+            report.expects(:calculate_metrics)
+            report.expects(:to_report)
+
+            report.finalize(false, "rspec message")
+
+            expect(report.instance_variable_get("@success")).to be(false)
+            expect(report.instance_variable_get("@fail_message")).to eq("rspec message")
+          end
+        end
+
+        describe "#calculate_metrics" do
+          it "should calculate the right metrics" do
+            report.store_task_results
+            metrics = report.calculate_metrics
+
+            expect(metrics).to include(
+              "task_count" => 2,
+              "task_types" => {
+                "rspec_type1" => {
+                  "count" => 1,
+                  "total_time" => 1.0,
+                  "pass" => 1,
+                  "fail" => 0
+                },
+                "rspec_type2" => {
+                  "count" => 1,
+                  "total_time" => 2.0,
+                  "pass" => 0,
+                  "fail" => 1
+                }
+              }
+            )
+          end
+        end
+
+        describe "#store_task_results" do
+          it "should store the right result data" do
+            tasks = report.store_task_results
+            expect(tasks).to eq(
+              [
+                {
+                  "type" => "rspec_type1",
+                  "set" => "rspec_set1",
+                  "description" => "rspec test1",
+                  "start_time" => Time.at(1484245208).utc,
+                  "end_time" => Time.at(1484245209).utc,
+                  "run_time" => 1.0,
+                  "ran" => true,
+                  "msg" => "rspec message",
+                  "success" => true
+                },
+                {
+                  "type" => "rspec_type2",
+                  "set" => "rspec_set2",
+                  "description" => "rspec test2",
+                  "start_time" => Time.at(1484245210).utc,
+                  "end_time" => Time.at(1484245212).utc,
+                  "run_time" => 2.0,
+                  "ran" => true,
+                  "msg" => "rspec message",
+                  "success" => false
+                }
+              ]
+            )
+          end
+        end
+
+        describe "#store_playbook_metadata" do
+          it "should store the right data" do
+            report.store_playbook_metadata
+            expect(report.instance_variable_get("@playbook_name")).to eq("test_playbook")
+            expect(report.instance_variable_get("@playbook_version")).to eq("1.1.2")
+          end
+        end
+
+        describe "#store_node_groups" do
+          it "should fetch all the node sets" do
+            nodes.stubs(:keys).returns(["nodes1", "nodes2"])
+            nodes.stubs(:[]).with("nodes1").returns(["node1.1", "node1.2"])
+            nodes.stubs(:[]).with("nodes2").returns(["node2.1", "node2.2"])
+
+            report.store_node_groups
+            expect(report.instance_variable_get("@nodes")).to eq(
+              "nodes1" => ["node1.1", "node1.2"],
+              "nodes2" => ["node2.1", "node2.2"]
+            )
+          end
+        end
+
+        describe "#store_static_inputs" do
+          it "should fetch all the inputs" do
+            inputs.prepare(
+              "cluster" => "alpha",
+              "two" => "2"
+            )
+
+            report.store_static_inputs
+
+            expect(report.instance_variable_get("@inputs")["static"]).to eq(
+              "cluster" => "alpha",
+              "two" => "2"
+            )
+          end
+        end
+
+        describe "#append_log" do
+          it "should append the log correctly" do
+            report.append_log(t = Time.now, :debug, "x:1:1", "rspec test")
+            expect(report.instance_variable_get("@logs")[0]).to eq(
+              "time" => t.utc.to_i,
+              "level" => "debug",
+              "from" => "x:1:1",
+              "msg" => "rspec test"
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/mcollective/util/playbook/task_result_spec.rb
+++ b/spec/unit/mcollective/util/playbook/task_result_spec.rb
@@ -23,19 +23,20 @@ module MCollective
 
             expect(tr.ran).to be(false)
 
-            tr.timed_run(task)
+            tr.timed_run(task, "rspec")
 
             expect(tr.task).to be(task)
             expect(tr.msg).to eq("rspec")
             expect(tr.data).to eq([:rspec])
             expect(tr.success).to be(true)
             expect(tr.ran).to be(true)
+            expect(tr.set).to eq("rspec")
           end
 
           it "should support fail_ok" do
             runner = stub(:run => [false, "rspec", [:rspec]])
             task = {:runner => runner, :properties => {"fail_ok" => true}}
-            tr.timed_run(task)
+            tr.timed_run(task, "rspec")
 
             expect(tr.task).to be(task)
             expect(tr.msg).to eq("rspec")
@@ -47,7 +48,7 @@ module MCollective
             runner = stub
             runner.stubs(:run).raises("rspec")
             task = {:runner => runner}
-            tr.timed_run(task)
+            tr.timed_run(task, "rspec")
 
             expect(tr.task).to be(task)
             expect(tr.msg).to match(/Running task .+ failed unexpectedly: RuntimeError: rspec/)

--- a/spec/unit/mcollective/util/playbook/task_result_spec.rb
+++ b/spec/unit/mcollective/util/playbook/task_result_spec.rb
@@ -5,7 +5,22 @@ module MCollective
   module Util
     class Playbook
       describe TaskResult do
-        let(:tr) { TaskResult.new }
+        let(:runner) { stub(:run => [true, "rspec", [:rspec]]) }
+        let(:tr) { TaskResult.new(task) }
+        let(:task) do
+          {
+            :description => "rspec task",
+            :type => "rspec",
+            :runner => runner,
+            :properties => {}
+          }
+        end
+
+        describe "#task_type" do
+          it "should get the right type" do
+            expect(tr.task_type).to eq("rspec")
+          end
+        end
 
         describe "#run_time" do
           it "should calculate the right elapsed time" do
@@ -18,12 +33,9 @@ module MCollective
 
         describe "#timed_run" do
           it "should run and update properties" do
-            runner = stub(:run => [true, "rspec", [:rspec]])
-            task = {:runner => runner}
-
             expect(tr.ran).to be(false)
 
-            tr.timed_run(task, "rspec")
+            tr.timed_run("rspec")
 
             expect(tr.task).to be(task)
             expect(tr.msg).to eq("rspec")
@@ -31,12 +43,11 @@ module MCollective
             expect(tr.success).to be(true)
             expect(tr.ran).to be(true)
             expect(tr.set).to eq("rspec")
+            expect(tr.description).to eq("rspec task")
           end
 
           it "should support fail_ok" do
-            runner = stub(:run => [false, "rspec", [:rspec]])
-            task = {:runner => runner, :properties => {"fail_ok" => true}}
-            tr.timed_run(task, "rspec")
+            tr.timed_run("rspec")
 
             expect(tr.task).to be(task)
             expect(tr.msg).to eq("rspec")
@@ -45,10 +56,8 @@ module MCollective
           end
 
           it "should handle exceptions" do
-            runner = stub
             runner.stubs(:run).raises("rspec")
-            task = {:runner => runner}
-            tr.timed_run(task, "rspec")
+            tr.timed_run("rspec")
 
             expect(tr.task).to be(task)
             expect(tr.msg).to match(/Running task .+ failed unexpectedly: RuntimeError: rspec/)

--- a/spec/unit/mcollective/util/playbook/tasks_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks_spec.rb
@@ -120,7 +120,7 @@ module MCollective
 
           it "should stop executing a set when the first failed task is met" do
             task_list["tasks"] << task_list["tasks"][0].clone
-            tasks.expects(:run_task).with(task_list["tasks"][0], true).returns(false)
+            tasks.expects(:run_task).with(task_list["tasks"][0], "tasks", true).returns(false)
 
             expect(tasks.run_set("tasks")).to be(false)
           end
@@ -149,21 +149,21 @@ module MCollective
 
           it "should run the pre_task and fail if it fails" do
             tasks.expects(:run_set).with("pre_task").returns(false)
-            expect(tasks.run_task(task_list["tasks"][0])).to be(false)
+            expect(tasks.run_task(task_list["tasks"][0], "tasks")).to be(false)
           end
 
           it "should support retries" do
             task[:runner].expects(:run).twice.returns([false, "fail 1", :x], [false, "fail 2", :x])
             tasks.expects(:sleep).with(20)
 
-            expect(tasks.run_task(task)).to be(false)
+            expect(tasks.run_task(task, "tasks")).to be(false)
           end
 
           it "should run a task with retries just once if it passes" do
             task[:runner].expects(:run).returns([true, "pass 1", :x])
             tasks.expects(:sleep).never
 
-            expect(tasks.run_task(task)).to be(true)
+            expect(tasks.run_task(task, "tasks")).to be(true)
           end
 
           it "should support fail_ok" do
@@ -171,21 +171,21 @@ module MCollective
             task[:runner].expects(:run).returns([false, "fail 1", :x])
             tasks.expects(:sleep).never
 
-            expect(tasks.run_task(task)).to be(true)
+            expect(tasks.run_task(task, "tasks")).to be(true)
           end
 
           it "should support post_task hook and fail if it fails" do
             task[:runner].stubs(:run).returns([true, "pass 1", :x])
             tasks.expects(:run_set).with("post_task").returns(true)
-            expect(tasks.run_task(task)).to be(true)
+            expect(tasks.run_task(task, "tasks")).to be(true)
 
             tasks.expects(:run_set).with("post_task").returns(false)
-            expect(tasks.run_task(task)).to be(false)
+            expect(tasks.run_task(task, "tasks")).to be(false)
           end
 
           it "should update the results" do
             task[:runner].expects(:run).returns([true, "pass 1", [:x]])
-            tasks.run_task(task_list["tasks"][0])
+            tasks.run_task(task_list["tasks"][0], "tasks")
 
             result = tasks.results.first
             expect(result.task).to be(task)


### PR DESCRIPTION
This adds the ability for the playbook to produce a report

Reports are always produced and returned after a run, the CLI has a
option to save it to a YAML file optionally, off by default

Close #88 