### PR TITLE
(#145) Improve file name handling for reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/01/13|145   |Improve file name handling for reports                                                                   |
 |2017/01/13|143   |Always use the identity cert on windows                                                                  |
 |2017/01/12|      |Release 0.0.18                                                                                           |
 |2017/01/12|      |Release 0.0.17                                                                                           |

--- a/lib/mcollective/util/playbook/report.rb
+++ b/lib/mcollective/util/playbook/report.rb
@@ -2,6 +2,8 @@ module MCollective
   module Util
     class Playbook
       class Report
+        attr_reader :timestamp
+
         def initialize(playbook)
           @playbook = playbook
           @logs = []


### PR DESCRIPTION
Now when specifying --report a file name is chosen containing the date
and time and shown at the end.

The file can be overridden using --report-file

A small summary is shown at the end of the book run

Close #145 