### PR TITLE
(#149) Add data sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/01/21|149   |Support data sources, dynamic inputs, data source read and write tasks                                   |
 |2017/01/13|      |Release 0.0.19                                                                                           |
 |2017/01/13|147   |Add a color option to the slack task and make it generally prettier                                      |
 |2017/01/13|145   |Improve file name handling for reports                                                                   |

--- a/lib/mcollective/util/playbook/data_stores.rb
+++ b/lib/mcollective/util/playbook/data_stores.rb
@@ -1,0 +1,181 @@
+require_relative "data_stores/memory_data_store"
+
+module MCollective
+  module Util
+    class Playbook
+      class DataStores
+        def initialize(playbook)
+          @playbook = playbook
+          @stores = {}
+        end
+
+        # Determines if a path is in the valid form and a known store
+        #
+        # @param path [String] example data_store/key_name
+        # @return [Boolean]
+        def valid_path?(path)
+          store, _ = parse_path(path)
+          include?(store)
+        rescue
+          false
+        end
+
+        # Parse a normal format data path
+        #
+        # @param path [String] example data_store/key_name
+        # @return [String, String] store name and key name
+        # @raise [StandardError] for incorrectly formatted paths
+        def parse_path(path)
+          if path =~ /^([a-zA-Z0-9\-\_]+)\/(.+)$/
+            [$1, $2]
+          else
+            raise("Invalid data store path %s" % [path])
+          end
+        end
+
+        # Reads from a path
+        #
+        # @param path [String] example data_store/key_name
+        # @return [Object] data from the data store
+        # @raise [StandardError] when reading from the key fails
+        # @raise [StandardError] for unknown stores
+        def read(path)
+          store, key = parse_path(path)
+
+          Log.debug("Reading key %s from data store %s" % [key, store])
+
+          self[store].read(key)
+        rescue
+          raise("Could not read key %s: %s: %s" % [path, $!.class, $!.to_s])
+        end
+
+        # Writes to a path
+        #
+        # @param path [String] example data_store/key_name
+        # @param value [Object] data to write to the path
+        # @return [Object] the value written on success
+        # @raise [StandardError] when reading from the key fails
+        # @raise [StandardError] for unknown stores
+        def write(path, value)
+          store, key = parse_path(path)
+
+          Log.debug("Storing data in key %s within data store %s" % [key, store])
+          self[store].write(key, value)
+        end
+
+        # Deletes a path
+        #
+        # @param path [String] example data_store/key_name
+        # @return [Object,nil] the deleted data if possible
+        # @raise [StandardError] when reading from the key fails
+        # @raise [StandardError] for unknown stores
+        def delete(path)
+          store, key = parse_path(path)
+
+          Log.debug("Deleting key %s from data store %s" % [key, store])
+          self[store].delete(key)
+        end
+
+        # Members registered in a service
+        #
+        # @param path [String] example data_store/key_name
+        # @return [Array<String>]
+        # @raise [StandardError] when reading from the key fails
+        # @raise [StandardError] for unknown stores
+        def members(path)
+          store, service = parse_path(path)
+
+          Log.debug("Retrieving service members for service %s from data store %s" % [service, store])
+          self[store].members(service)
+        end
+
+        # Attempts to lock a named semaphore, waits until it succeeds
+        #
+        # @param path [String] example data_store/key_name
+        # @raise [StandardError] when reading from the key fails
+        # @raise [StandardError] for unknown stores
+        def lock(path)
+          store, key = parse_path(path)
+
+          Log.debug("Obtaining lock %s on data store %s" % [key, store])
+          self[store].lock(key)
+        end
+
+        # Attempts to unlock a named semaphore
+        #
+        # @param path [String] example data_store/key_name
+        # @raise [StandardError] when reading from the key fails
+        # @raise [StandardError] for unknown stores
+        def release(path)
+          store, key = parse_path(path)
+
+          Log.debug("Releasing lock %s on data store %s" % [key, store])
+          self[store].release(key)
+        end
+
+        # Finds a named store instance
+        #
+        # @param store [String] a store name
+        # @raise [StandardError] for unknown stores
+        def [](store)
+          raise("Unknown data store %s" % store) unless include?(store)
+
+          @stores[store][:store]
+        end
+
+        # List of known store names
+        #
+        # @return [Array<String>]
+        def keys
+          @stores.keys
+        end
+
+        # Determines if a store is known
+        #
+        # @return [Boolean]
+        def include?(store)
+          @stores.include?(store)
+        end
+
+        # Prepares all the stores
+        def prepare
+          @stores.each do |_, properties|
+            properties[:store].from_hash(properties[:properties]).prepare
+          end
+        end
+
+        # Creates a store instance for a given type
+        #
+        # @return [DataStores::Base] data store instance
+        # @raise [NameError] for unknown types
+        def store_for(type)
+          klass_name = "%sDataStore" % type.capitalize
+
+          DataStores.const_get(klass_name).new(@playbook)
+        rescue NameError
+          raise("Cannot find a handler for Data Store type %s" % type)
+        end
+
+        # Initialize the data stores from playbook data
+        #
+        # @param data [Hash] playbook format data
+        # @return [DataStores]
+        def from_hash(data)
+          @stores.clear
+
+          data.each do |store, props|
+            Log.debug("Loading data store %s" % [store])
+
+            @stores[store] = {
+              :properties => props,
+              :type => props["type"],
+              :store => store_for(props["type"])
+            }
+          end
+
+          self
+        end
+      end
+    end
+  end
+end

--- a/lib/mcollective/util/playbook/data_stores/base.rb
+++ b/lib/mcollective/util/playbook/data_stores/base.rb
@@ -1,0 +1,48 @@
+module MCollective
+  module Util
+    class Playbook
+      class DataStores
+        class Base
+          def initialize(playbook)
+            @playbook = playbook
+
+            startup_hook
+          end
+
+          def startup_hook; end
+
+          def prepare; end
+
+          def from_hash(properties)
+            @properties = properties
+            self
+          end
+
+          def release(key)
+            raise(NotImplementedError, "release not implemented", caller)
+          end
+
+          def lock(key)
+            raise(NotImplementedError, "lock not implemented", caller)
+          end
+
+          def members(key)
+            raise(NotImplementedError, "members not implemented", caller)
+          end
+
+          def delete(key)
+            raise(NotImplementedError, "delete not implemented", caller)
+          end
+
+          def write(key, value)
+            raise(NotImplementedError, "write not implemented", caller)
+          end
+
+          def read(key)
+            raise(NotImplementedError, "read not implemented", caller)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mcollective/util/playbook/data_stores/memory_data_store.rb
+++ b/lib/mcollective/util/playbook/data_stores/memory_data_store.rb
@@ -1,0 +1,61 @@
+require_relative "base"
+require "thread"
+
+module MCollective
+  module Util
+    class Playbook
+      class DataStores
+        class MemoryDataStore < Base
+          def startup_hook
+            @store = {}
+            @locks = {}
+            @locks_mutex = Mutex.new
+          end
+
+          def read(key)
+            raise("No such key %s" % [key]) unless include?(key)
+
+            Marshal.load(Marshal.dump(@store[key]))
+          end
+
+          def write(key, value)
+            @store[key] = value
+          end
+
+          def delete(key)
+            @store.delete(key)
+          end
+
+          def lock(key)
+            @locks_mutex.synchronize do
+              @locks[key] ||= Mutex.new
+            end
+
+            @locks[key].lock
+          end
+
+          def release(key)
+            @locks_mutex.synchronize do
+              @locks[key] ||= Mutex.new
+            end
+
+            begin
+              @locks[key].unlock
+            rescue ThreadError
+              Log.warn("Attempted to release lock %s but it was already unlocked" % key)
+            end
+          end
+
+          def include?(key)
+            @store.include?(key)
+          end
+
+          def prepare
+            @store.clear
+            @locks.clear
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mcollective/util/playbook/report.rb
+++ b/lib/mcollective/util/playbook/report.rb
@@ -33,6 +33,7 @@ module MCollective
 
           store_playbook_metadata
           store_static_inputs
+          store_dynamic_inputs
           store_node_groups
           store_task_results
           calculate_metrics
@@ -114,8 +115,12 @@ module MCollective
           end
         end
 
+        def store_dynamic_inputs
+          @inputs["dynamic"] = @playbook.dynamic_inputs
+        end
+
         def store_static_inputs
-          @playbook.inputs.each do |key|
+          @playbook.static_inputs.each do |key|
             @inputs["static"][key] = @playbook.input_value(key)
           end
         end

--- a/lib/mcollective/util/playbook/tasks.rb
+++ b/lib/mcollective/util/playbook/tasks.rb
@@ -5,6 +5,7 @@ require_relative "tasks/mcollective_assert_task"
 require_relative "tasks/shell_task"
 require_relative "tasks/slack_task"
 require_relative "tasks/webhook_task"
+require_relative "tasks/data_task"
 
 module MCollective
   module Util

--- a/lib/mcollective/util/playbook/tasks/data_task.rb
+++ b/lib/mcollective/util/playbook/tasks/data_task.rb
@@ -1,0 +1,44 @@
+module MCollective
+  module Util
+    class Playbook
+      class Tasks
+        class DataTask < Base
+          attr_reader :action, :key, :value, :options
+
+          def run
+            case @action
+            when "write"
+              written = @playbook.data_stores.write(@key, @value)
+              [true, "Wrote value to %s" % [@key], [written]]
+
+            when "delete"
+              deleted = @playbook.data_stores.delete(@key)
+              [true, "Deleted data item %s" % [@key], [deleted]]
+
+            else
+              [false, "Unknown action %s" % [@action], []]
+            end
+          rescue
+            msg = "Could not perform %s on data %s: %s: %s" % [@action, @key, $!.class, $!.to_s]
+            Log.debug(msg)
+            Log.debug($!.backtrace.join("\t\n"))
+
+            [false, msg, []]
+          end
+
+          def validate_configuration!
+            raise("Action should be one of delete or write") unless ["delete", "write"].include?(@action)
+            raise("A key to act on is needed") unless @key
+            raise("A value is needed when writing") if @action == "write" && @value.nil?
+          end
+
+          def from_hash(properties)
+            @action = properties["action"]
+            @key = properties["key"]
+            @value = properties["value"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/playbooks/playbook.yaml
+++ b/spec/fixtures/playbooks/playbook.yaml
@@ -13,6 +13,13 @@ uses:
   rpcutil: "~1.0.0"
   puppet: "~1.11.0"
 
+data_stores:
+  mem_store:
+    type: memory
+
+  another:
+    type: memory
+
 inputs:
   cluster:
     description: Cluster to deploy
@@ -25,6 +32,13 @@ inputs:
     description: input 2 description
     type: String
     validation: ":string"
+
+  data_backed:
+    description: data source backed input
+    type: String
+    validation: ":string"
+    default: "data_backed_default"
+    data: "mem_store/data_backed"
 
 nodes:
   load_balancers:

--- a/spec/unit/mcollective/util/playbook/data_stores/memory_data_store_spec.rb
+++ b/spec/unit/mcollective/util/playbook/data_stores/memory_data_store_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+require "mcollective/util/playbook"
+
+module MCollective
+  module Util
+    class Playbook
+      class DataStores
+        describe MemoryDataStore do
+          let(:ds) { MemoryDataStore.new(stub) }
+          let(:store) { ds.instance_variable_get("@store") }
+          let(:locks) { ds.instance_variable_get("@locks") }
+
+          describe "#prepare" do
+            it "should clear the store and locks" do
+              store["X"] = "y"
+              locks["X"] = "y"
+              ds.prepare
+
+              expect(locks).to be_empty
+              expect(store).to be_empty
+            end
+          end
+
+          describe "#include?" do
+            it "should find data correctly" do
+              expect(ds.include?("rspec")).to be(false)
+              ds.write("rspec", 1)
+              expect(ds.include?("rspec")).to be(true)
+            end
+          end
+
+          describe "#release" do
+            it "should not fail unlocking an unlocked mutex" do
+              ds.release("x")
+            end
+
+            it "should release the right lock" do
+              ds.lock("x")
+              expect(locks["x"]).to be_locked
+              ds.release("x")
+              expect(locks["x"]).to_not be_locked
+            end
+          end
+
+          describe "#lock" do
+            it "should create and lock the lock" do
+              expect(locks).to eq({})
+              ds.lock("x")
+              expect(locks["x"]).to be_a(Mutex)
+              expect(locks["x"]).to be_locked
+            end
+          end
+
+          describe "#delete" do
+            it "should delete the data" do
+              store["x"] = "rsx"
+              store["y"] = "rsy"
+              ds.delete("x")
+              expect(store).to eq("y" => "rsy")
+            end
+          end
+
+          describe "#write" do
+            it "should store the data" do
+              ds.write("x", "rspec")
+              expect(store["x"]).to eq("rspec")
+            end
+          end
+
+          describe "#read" do
+            it "should fail for unknown keys" do
+              expect { ds.read("x") }.to raise_error("No such key x")
+            end
+
+            it "should read the right key cloned" do
+              store["x"] = "rspec"
+              expect(ds.read("x")).to_not be(store["x"])
+              expect(ds.read("x")).to eq("rspec")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/mcollective/util/playbook/data_stores_spec.rb
+++ b/spec/unit/mcollective/util/playbook/data_stores_spec.rb
@@ -1,0 +1,114 @@
+require "spec_helper"
+require "mcollective/util/playbook"
+
+module MCollective
+  module Util
+    class Playbook
+      describe DataStores do
+        let(:ds) { DataStores.new(stub) }
+        let(:stores) { ds.instance_variable_get("@stores") }
+        let(:store) { ds["mem_store"] }
+        let(:playbook_fixture) { YAML.load(File.read("spec/fixtures/playbooks/playbook.yaml")) }
+
+        before(:each) do
+          ds.from_hash(playbook_fixture["data_stores"])
+        end
+
+        describe "#from_hash" do
+          it "should create the right data" do
+            ds.from_hash(playbook_fixture["data_stores"])
+            expect(stores.keys).to eq(["mem_store", "another"])
+            expect(stores["mem_store"]).to include(
+              :properties => {"type" => "memory"},
+              :type => "memory",
+              :store => a_kind_of(DataStores::MemoryDataStore)
+            )
+          end
+        end
+
+        describe "#store_for" do
+          it "should create the correct type of store" do
+            expect(ds.store_for("memory")).to be_a(DataStores::MemoryDataStore)
+
+            expect { ds.store_for("rspec") }.to raise_error("Cannot find a handler for Data Store type rspec")
+          end
+        end
+
+        describe "#include?" do
+          it "should correctly check for known stores" do
+            expect(ds.include?("mem_store")).to be(true)
+            expect(ds.include?("rspec")).to be(false)
+          end
+        end
+
+        describe "#keys" do
+          it "should list all stores" do
+            expect(ds.keys).to eq(["mem_store", "another"])
+          end
+        end
+
+        describe "#[]" do
+          it "should fetch the right store" do
+            expect(ds["mem_store"]).to be(stores["mem_store"][:store])
+          end
+        end
+
+        describe "#release" do
+          it "should release the right lock" do
+            store.expects(:release).with("rspec")
+            ds.release("mem_store/rspec")
+          end
+        end
+
+        describe "#lock" do
+          it "should lock the right lock" do
+            store.expects(:lock).with("rspec")
+            ds.lock("mem_store/rspec")
+          end
+        end
+
+        describe "#members" do
+          it "should fetch the right service members" do
+            store.expects(:members).with("rspec").returns(["node1"])
+            expect(ds.members("mem_store/rspec")).to eq(["node1"])
+          end
+        end
+
+        describe "#delete" do
+          it "should delete the right key" do
+            store.expects(:delete).with("rspec")
+            ds.delete("mem_store/rspec")
+          end
+        end
+
+        describe "#write" do
+          it "should write the right values" do
+            store.expects(:write).with("rspec", "rsv").returns("rsv")
+            expect(ds.write("mem_store/rspec", "rsv")).to eq("rsv")
+          end
+        end
+
+        describe "#read" do
+          it "should read the right key from the store" do
+            store.expects(:read).with("rspec").returns("rsv")
+            expect(ds.read("mem_store/rspec")).to eq("rsv")
+          end
+        end
+
+        describe "#parse_path" do
+          it "should correctly parse the path" do
+            expect(ds.parse_path("mem_store/y")).to eq(["mem_store", "y"])
+            expect {ds.parse_path("x") }.to raise_error("Invalid data store path x")
+          end
+        end
+
+        describe "#valid_path?" do
+          it "should correctly validate paths" do
+            expect(ds.valid_path?("x/y")).to be(false)
+            expect(ds.valid_path?("mem_store/y")).to be(true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/mcollective/util/playbook/report_spec.rb
+++ b/spec/unit/mcollective/util/playbook/report_spec.rb
@@ -48,6 +48,7 @@ module MCollective
           it "should fetch all data and produce a report" do
             report.expects(:store_playbook_metadata)
             report.expects(:store_static_inputs)
+            report.expects(:store_dynamic_inputs)
             report.expects(:store_node_groups)
             report.expects(:store_task_results)
             report.expects(:calculate_metrics)
@@ -136,6 +137,19 @@ module MCollective
               "nodes1" => ["node1.1", "node1.2"],
               "nodes2" => ["node2.1", "node2.2"]
             )
+          end
+        end
+
+        describe "#store_dynamic_inputs" do
+          it "should fetch all the inputs" do
+            inputs.prepare(
+              "cluster" => "alpha",
+              "two" => "2"
+            )
+
+            report.store_dynamic_inputs
+
+            expect(report.instance_variable_get("@inputs")["dynamic"]).to eq(["data_backed"])
           end
         end
 

--- a/spec/unit/mcollective/util/playbook/tasks/data_task_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks/data_task_spec.rb
@@ -1,0 +1,77 @@
+require "spec_helper"
+require "mcollective/util/playbook"
+
+module MCollective
+  module Util
+    class Playbook
+      class Tasks
+        describe DataTask do
+          let(:ds) { stub }
+          let(:playbook) { stub(:data_stores => ds) }
+          let(:task) { DataTask.new(playbook) }
+
+          describe "#run" do
+            it "should support writing" do
+              task.from_hash("action" => "write", "key" => "store/y", "value" => "x")
+              ds.expects(:write).with("store/y", "x").returns("x")
+              expect(task.run).to eq([true, "Wrote value to store/y", ["x"]])
+            end
+
+            it "should support deleting" do
+              task.from_hash("action" => "delete", "key" => "store/y")
+              ds.expects(:delete).with("store/y").returns("x")
+              expect(task.run).to eq([true, "Deleted data item store/y", ["x"]])
+            end
+
+            it "should fail otherwise" do
+              task.from_hash("action" => "foo", "key" => "store/y", "value" => "x")
+              expect(task.run).to eq([false, "Unknown action foo", []])
+
+              task.from_hash("action" => "delete", "key" => "store/y")
+              ds.expects(:delete).raises("rspec error")
+              expect(task.run).to eq([false, "Could not perform delete on data store/y: RuntimeError: rspec error", []])
+            end
+          end
+
+          describe "#validate_configuration!" do
+            it "should expect an action" do
+              task.from_hash({})
+              expect { task.validate_configuration! }.to raise_error("Action should be one of delete or write")
+
+              task.from_hash("action" => "rspec")
+              expect { task.validate_configuration! }.to raise_error("Action should be one of delete or write")
+            end
+
+            it "should expect a key" do
+              task.from_hash("action" => "delete")
+              expect { task.validate_configuration! }.to raise_error("A key to act on is needed")
+            end
+
+            it "should expect a value when writing" do
+              task.from_hash("action" => "write", "key" => "x/y")
+              expect { task.validate_configuration! }.to raise_error("A value is needed when writing")
+
+              task.from_hash("action" => "delete", "key" => "x/y")
+              task.validate_configuration!
+            end
+          end
+
+          describe "#from_hash" do
+            it "should store the properties" do
+              task.from_hash(
+                "action" => "write",
+                "value" => "hello",
+                "key" => "mem/x",
+                "options" => {"overwrite" => true}
+              )
+
+              expect(task.key).to eq("mem/x")
+              expect(task.action).to eq("write")
+              expect(task.value).to eq("hello")
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds data sources that can be used for dynamic inputs and storing
data for use in playbooks or elsewhere

A memory data store is included, consul and etcd will come

Datastores support:

  * Read
  * Write
  * Delete
  * Locks
  * Service Memberships

Playbooks for now support dynamic inputs that are data source backed and
have a data task that can read and write to teh data stores

In future playbook level locks and task level locks will be added and
node sets against service membership