### PR TITLE
(#155) Allow dynamic only inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/01/21|155   |Allow inputs to be forced to dynamic only inputs                                                         |
 |2017/01/21|149   |Support data sources, dynamic inputs, data source read and write tasks                                   |
 |2017/01/13|      |Release 0.0.19                                                                                           |
 |2017/01/13|147   |Add a color option to the slack task and make it generally prettier                                      |

--- a/lib/mcollective/util/playbook/inputs.rb
+++ b/lib/mcollective/util/playbook/inputs.rb
@@ -40,6 +40,8 @@ module MCollective
           @inputs.each do |input, props|
             i_props = props[:properties]
 
+            next if i_props["dynamic_only"]
+
             type = case i_props["type"]
                    when :string, "String"
                      String
@@ -77,6 +79,7 @@ module MCollective
           @inputs.each do |input, _|
             next unless data.include?(input)
             next if data[input].nil?
+            next if @inputs[input][:properties]["dynamic_only"]
 
             validate_data(input, data[input])
             @inputs[input][:value] = data[input]

--- a/spec/fixtures/playbooks/playbook.yaml
+++ b/spec/fixtures/playbooks/playbook.yaml
@@ -40,6 +40,14 @@ inputs:
     default: "data_backed_default"
     data: "mem_store/data_backed"
 
+  forced_dynamic:
+    description: "Forced dynamic input"
+    type: String
+    validation: ":string"
+    default: "data_backed_default"
+    dynamic_only: true
+    data: "mem_store/data_backed"
+
 nodes:
   load_balancers:
     type: mcollective

--- a/spec/unit/mcollective/util/playbook/report_spec.rb
+++ b/spec/unit/mcollective/util/playbook/report_spec.rb
@@ -149,7 +149,7 @@ module MCollective
 
             report.store_dynamic_inputs
 
-            expect(report.instance_variable_get("@inputs")["dynamic"]).to eq(["data_backed"])
+            expect(report.instance_variable_get("@inputs")["dynamic"]).to eq(["data_backed", "forced_dynamic"])
           end
         end
 


### PR DESCRIPTION
Inputs with a data source attached can be dynamic or static, this allows
a input to be forced dynamic - it will not appear on the CLI and data
provided to the API will be ignored

Closes #155 