### PR TITLE
(#163) do template processing on description

### DIFF
--- a/lib/mcollective/util/playbook/tasks.rb
+++ b/lib/mcollective/util/playbook/tasks.rb
@@ -56,7 +56,8 @@ module MCollective
           result = task[:result]
           task_runner = task[:runner]
 
-          Log.info("About to run task: %s" % properties["description"]) if properties["description"]
+          Log.info("About to run task: %s" % t(task[:runner].description))
+          result.description = t(task[:runner].description)
 
           if hooks && !run_set("pre_task")
             Log.warn("Failing task because a critical pre_task hook failed")

--- a/lib/mcollective/util/playbook/tasks/base.rb
+++ b/lib/mcollective/util/playbook/tasks/base.rb
@@ -5,6 +5,8 @@ module MCollective
         class Base
           attr_accessor :description
 
+          include TemplateUtil
+
           def initialize(playbook)
             @playbook = playbook
 
@@ -14,7 +16,7 @@ module MCollective
           def startup_hook; end
 
           def to_s
-            "#<%s description: %s>" % [self.class, description]
+            "#<%s description: %s>" % [self.class, t(description)]
           end
 
           def run_task(result)

--- a/lib/mcollective/util/playbook/tasks/mcollective_task.rb
+++ b/lib/mcollective/util/playbook/tasks/mcollective_task.rb
@@ -7,7 +7,6 @@ module MCollective
             @properties = {}
             @post = []
             @nodes = []
-            @description = nil
           end
 
           # Creates and cache an RPC::Client for the configured agent

--- a/spec/unit/mcollective/util/playbook/tasks_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks_spec.rb
@@ -145,6 +145,7 @@ module MCollective
 
           before(:each) do
             tasks.stubs(:t).with(task[:properties]).returns(task[:properties])
+            tasks.stubs(:t).with(task[:description]).returns(task[:description])
             tasks.stubs(:run_set).returns(true)
           end
 


### PR DESCRIPTION
Description is saved into the task data and result data early on, while
task templates are parsed just before running the task, this resulted in
descriptions not being processed in places where its user visible

This does some updating of descriptions in logs and reports

Closes #163 