### PR TITLE
(#176) Use correct public cert dir on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/02/09|176   |Create the choria public certs in the right directory on windows                                         |
 |2017/02/06|174   |Set the mcollective summary as task outcome when its requested                                           |
 |2017/01/31|135   |Add a choria logo to the slack task user                                                                 |
 |2017/01/29|      |Release 0.0.21                                                                                           |

--- a/lib/mcollective/security/choria.rb
+++ b/lib/mcollective/security/choria.rb
@@ -470,7 +470,11 @@ module MCollective
       # @return [String]
       # @raise [StandardError] when creating the directory fails
       def server_public_cert_dir
-        dir = "/etc/puppetlabs/mcollective/choria_security/public_certs"
+        if Util.windows?
+          dir = File.join(Util.windows_prefix, "choria_security", "public_certs")
+        else
+          dir = "/etc/puppetlabs/mcollective/choria_security/public_certs"
+        end
 
         FileUtils.mkdir_p(dir) unless File.directory?(dir)
 

--- a/spec/unit/mcollective/security/choria_spec.rb
+++ b/spec/unit/mcollective/security/choria_spec.rb
@@ -384,6 +384,13 @@ module MCollective
         FileUtils.expects(:mkdir_p).never
         expect(security.server_public_cert_dir).to eq("/etc/puppetlabs/mcollective/choria_security/public_certs")
       end
+
+      it "should support windows" do
+        Util.stubs(:windows?).returns(true)
+        Util.stubs(:windows_prefix).returns("c:/nonexisting")
+        File.expects(:directory?).with("c:/nonexisting/choria_security/public_certs").returns(true)
+        expect(security.server_public_cert_dir).to eq("c:/nonexisting/choria_security/public_certs")
+      end
     end
 
     describe "#callerid" do


### PR DESCRIPTION
The public cert dir was hard coded to unix paths, this adds windows path
handling

Close #176 